### PR TITLE
Add local IntentBook deploy and method exercise scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ coverage/
 # Local SQLite artifacts
 packages/relayer/data/
 *.db
+
+# IntentBook local deployment artifacts
+packages/contracts/.intentbook.local.env

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -17,3 +17,29 @@ forge create src/ClawCore.sol:ClawCore \
   --rpc-url "$RPC_URL" \
   --private-key "$DEPLOYER_PRIVATE_KEY"
 ```
+
+## IntentBook local deploy + method exercise
+
+Prerequisite: set these in repository root `.env`
+
+```bash
+RPC_URL=http://127.0.0.1:8545
+CHAIN_ID=10143
+DEPLOYER_PRIVATE_KEY=0x...
+```
+
+Deploy `IntentBook` + `MockSnapshotBook`:
+
+```bash
+./packages/contracts/scripts/deploy-intentbook-local.sh
+```
+
+Exercise IntentBook methods (onchain tx):
+
+```bash
+./packages/contracts/scripts/test-intentbook-methods-local.sh
+```
+
+The deploy script writes addresses to:
+
+- `packages/contracts/.intentbook.local.env`

--- a/packages/contracts/script/DeployIntentBook.s.sol
+++ b/packages/contracts/script/DeployIntentBook.s.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "forge-std/Script.sol";
+import "forge-std/console2.sol";
+import {IntentBook} from "../src/IntentBook.sol";
+import {MockSnapshotBook} from "../src/mocks/MockSnapshotBook.sol";
+
+contract DeployIntentBookScript is Script {
+    bytes32 internal constant DEFAULT_SNAPSHOT_HASH = keccak256("openclaw-local-snapshot-v1");
+
+    function run() external {
+        uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address owner = vm.addr(deployerPk);
+        address strategy = vm.envOr("STRATEGY_AGENT", owner);
+        uint256 thresholdWeight = vm.envOr("INTENT_THRESHOLD_WEIGHT", uint256(5));
+
+        vm.startBroadcast(deployerPk);
+
+        MockSnapshotBook snapshotBook = new MockSnapshotBook();
+        snapshotBook.setFinalized(DEFAULT_SNAPSHOT_HASH, true);
+
+        IntentBook intentBook = new IntentBook(owner, strategy, address(snapshotBook), thresholdWeight);
+
+        vm.stopBroadcast();
+
+        console2.log("OWNER", owner);
+        console2.log("STRATEGY_AGENT", strategy);
+        console2.log("SNAPSHOT_BOOK", address(snapshotBook));
+        console2.log("INTENT_BOOK", address(intentBook));
+        console2.logBytes32(DEFAULT_SNAPSHOT_HASH);
+    }
+}

--- a/packages/contracts/script/ExerciseIntentBookMethods.s.sol
+++ b/packages/contracts/script/ExerciseIntentBookMethods.s.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "forge-std/Script.sol";
+import "forge-std/console2.sol";
+import {IntentBook} from "../src/IntentBook.sol";
+import {MockSnapshotBook} from "../src/mocks/MockSnapshotBook.sol";
+
+contract ExerciseIntentBookMethodsScript is Script {
+    bytes32 internal constant INTENT_ATTESTATION_TYPEHASH =
+        keccak256("IntentAttestation(bytes32 intentHash,address verifier,uint64 expiresAt,uint256 nonce)");
+
+    IntentBook internal book;
+    MockSnapshotBook internal snapshotBook;
+
+    uint256 internal ownerPk;
+    address internal owner;
+
+    uint256 internal verifierPk1;
+    uint256 internal verifierPk2;
+    address internal verifier1;
+    address internal verifier2;
+
+    bytes32 internal snapshotHash;
+    bytes32 internal intentHash;
+
+    function run() external {
+        _loadConfig();
+
+        vm.startBroadcast(ownerPk);
+        _adminSetup();
+        _proposeIntent();
+        _attestIntent();
+        vm.stopBroadcast();
+
+        _assertState();
+
+        console2.log("IntentBook method exercise succeeded");
+        console2.log("INTENT_BOOK", address(book));
+        console2.log("INTENT_HASH");
+        console2.logBytes32(intentHash);
+    }
+
+    function _loadConfig() internal {
+        ownerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        owner = vm.addr(ownerPk);
+
+        book = IntentBook(vm.envAddress("INTENT_BOOK_ADDRESS"));
+        snapshotBook = MockSnapshotBook(vm.envAddress("SNAPSHOT_BOOK_ADDRESS"));
+
+        verifierPk1 = vm.envOr("TEST_VERIFIER_PK_1", uint256(0xB0B));
+        verifierPk2 = vm.envOr("TEST_VERIFIER_PK_2", uint256(0xC0C));
+        verifier1 = vm.addr(verifierPk1);
+        verifier2 = vm.addr(verifierPk2);
+
+        snapshotHash = keccak256("openclaw-local-snapshot-v1");
+        intentHash = keccak256("openclaw-local-intent-v1");
+    }
+
+    function _adminSetup() internal {
+        book.setVerifier(verifier1, true, 3);
+        book.setVerifier(verifier2, true, 2);
+        book.setDefaultThresholdWeight(5);
+        book.setStrategyAgent(owner);
+        book.setSnapshotBook(address(snapshotBook));
+        snapshotBook.setFinalized(snapshotHash, true);
+    }
+
+    function _proposeIntent() internal {
+        IntentBook.Constraints memory c = IntentBook.Constraints({
+            allowlistHash: bytes32(uint256(1)),
+            maxSlippageBps: 50,
+            maxNotional: 1_000_000 ether,
+            deadline: uint64(block.timestamp + 1 hours)
+        });
+
+        book.proposeIntent(intentHash, "ipfs://openclaw-intent-local", snapshotHash, c);
+    }
+
+    function _attestIntent() internal {
+        uint64 expiresAt = uint64(block.timestamp + 10 minutes);
+
+        address[] memory verifiers = new address[](2);
+        verifiers[0] = verifier1;
+        verifiers[1] = verifier2;
+
+        IntentBook.IntentAttestation[] memory atts = new IntentBook.IntentAttestation[](2);
+        atts[0] = IntentBook.IntentAttestation({
+            expiresAt: expiresAt,
+            nonce: 1,
+            signature: _sign(verifierPk1, _digest(intentHash, verifier1, expiresAt, 1))
+        });
+        atts[1] = IntentBook.IntentAttestation({
+            expiresAt: expiresAt,
+            nonce: 2,
+            signature: _sign(verifierPk2, _digest(intentHash, verifier2, expiresAt, 2))
+        });
+
+        book.attestIntent(intentHash, verifiers, atts);
+    }
+
+    function _assertState() internal view {
+        require(book.isIntentApproved(intentHash), "intent should be approved");
+
+        IntentBook.Intent memory i = book.getIntent(intentHash);
+        require(i.approved, "stored intent should be approved");
+        require(i.attestedWeight == 5, "attested weight mismatch");
+    }
+
+    function _digest(bytes32 _intentHash, address verifier, uint64 expiresAt, uint256 nonce)
+        internal
+        view
+        returns (bytes32)
+    {
+        bytes32 domainTypehash =
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                domainTypehash,
+                keccak256(bytes("ClawIntentBook")),
+                keccak256(bytes("1")),
+                block.chainid,
+                address(book)
+            )
+        );
+
+        bytes32 structHash =
+            keccak256(abi.encode(INTENT_ATTESTATION_TYPEHASH, _intentHash, verifier, expiresAt, nonce));
+
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+    }
+
+    function _sign(uint256 pk, bytes32 digest) internal returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+}

--- a/packages/contracts/scripts/deploy-intentbook-local.sh
+++ b/packages/contracts/scripts/deploy-intentbook-local.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+CONTRACTS_DIR="$ROOT_DIR/packages/contracts"
+DEPLOY_ENV_FILE="$CONTRACTS_DIR/.intentbook.local.env"
+
+if [[ -f "$ROOT_DIR/.env" ]]; then
+  set -a
+  source "$ROOT_DIR/.env"
+  set +a
+fi
+
+: "${RPC_URL:?RPC_URL is required in .env}"
+: "${CHAIN_ID:?CHAIN_ID is required in .env}"
+: "${DEPLOYER_PRIVATE_KEY:?DEPLOYER_PRIVATE_KEY is required in .env}"
+DEPLOYER_ADDRESS="$(cast wallet address --private-key "$DEPLOYER_PRIVATE_KEY")"
+
+if ! cast chain-id --rpc-url "$RPC_URL" >/dev/null 2>&1; then
+  if [[ "$RPC_URL" == http://127.0.0.1:* || "$RPC_URL" == http://localhost:* ]]; then
+    echo "[deploy] no local RPC at $RPC_URL, starting anvil..."
+    nohup anvil --host 127.0.0.1 --port 8545 --chain-id "$CHAIN_ID" >/tmp/openclaw-anvil.log 2>&1 &
+    sleep 1
+  else
+    echo "[deploy] RPC is unreachable: $RPC_URL"
+    exit 1
+  fi
+fi
+
+# Local anvil convenience: ensure deployer has enough gas balance.
+if [[ "$RPC_URL" == http://127.0.0.1:* || "$RPC_URL" == http://localhost:* ]]; then
+  cast rpc --rpc-url "$RPC_URL" anvil_setBalance "$DEPLOYER_ADDRESS" 0x3635C9ADC5DEA00000 >/dev/null 2>&1 || true
+fi
+
+echo "[deploy] running forge script..."
+cd "$CONTRACTS_DIR"
+OUT_FILE="/tmp/intentbook-deploy.out"
+forge script script/DeployIntentBook.s.sol:DeployIntentBookScript \
+  --rpc-url "$RPC_URL" \
+  --broadcast | tee "$OUT_FILE"
+
+RUN_JSON="$CONTRACTS_DIR/broadcast/DeployIntentBook.s.sol/$CHAIN_ID/run-latest.json"
+SNAPSHOT_BOOK_ADDRESS="$(jq -r '.transactions[] | select(.contractName=="MockSnapshotBook" and .transactionType=="CREATE") | .contractAddress' "$RUN_JSON" | tail -n1)"
+INTENT_BOOK_ADDRESS="$(jq -r '.transactions[] | select(.contractName=="IntentBook" and .transactionType=="CREATE") | .contractAddress' "$RUN_JSON" | tail -n1)"
+SNAPSHOT_HASH="$(jq -r '.transactions[] | select(.contractName=="MockSnapshotBook" and .function=="setFinalized(bytes32,bool)") | .arguments[0]' "$RUN_JSON" | tail -n1)"
+
+if [[ -z "$SNAPSHOT_BOOK_ADDRESS" || -z "$INTENT_BOOK_ADDRESS" ]]; then
+  echo "[deploy] failed to parse deployment addresses"
+  exit 1
+fi
+
+cat > "$DEPLOY_ENV_FILE" <<ENV
+INTENT_BOOK_ADDRESS=$INTENT_BOOK_ADDRESS
+SNAPSHOT_BOOK_ADDRESS=$SNAPSHOT_BOOK_ADDRESS
+DEFAULT_SNAPSHOT_HASH=$SNAPSHOT_HASH
+ENV
+
+echo "[deploy] wrote $DEPLOY_ENV_FILE"
+cat "$DEPLOY_ENV_FILE"

--- a/packages/contracts/scripts/test-intentbook-methods-local.sh
+++ b/packages/contracts/scripts/test-intentbook-methods-local.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+CONTRACTS_DIR="$ROOT_DIR/packages/contracts"
+DEPLOY_ENV_FILE="$CONTRACTS_DIR/.intentbook.local.env"
+
+if [[ -f "$ROOT_DIR/.env" ]]; then
+  set -a
+  source "$ROOT_DIR/.env"
+  set +a
+fi
+
+if [[ -f "$DEPLOY_ENV_FILE" ]]; then
+  set -a
+  source "$DEPLOY_ENV_FILE"
+  set +a
+fi
+
+: "${RPC_URL:?RPC_URL is required in .env}"
+: "${DEPLOYER_PRIVATE_KEY:?DEPLOYER_PRIVATE_KEY is required in .env}"
+
+if ! cast chain-id --rpc-url "$RPC_URL" >/dev/null 2>&1; then
+  if [[ "$RPC_URL" == http://127.0.0.1:* || "$RPC_URL" == http://localhost:* ]]; then
+    echo "[test] local RPC is not running. deploying local contracts (this starts anvil if needed)..."
+    "$CONTRACTS_DIR/scripts/deploy-intentbook-local.sh"
+    set -a
+    source "$DEPLOY_ENV_FILE"
+    set +a
+  else
+    echo "[test] RPC is unreachable: $RPC_URL"
+    exit 1
+  fi
+fi
+
+if [[ -z "${INTENT_BOOK_ADDRESS:-}" || -z "${SNAPSHOT_BOOK_ADDRESS:-}" ]]; then
+  echo "[test] missing deployment addresses. deploying first..."
+  "$CONTRACTS_DIR/scripts/deploy-intentbook-local.sh"
+  set -a
+  source "$DEPLOY_ENV_FILE"
+  set +a
+fi
+
+if [[ "$(cast code "$INTENT_BOOK_ADDRESS" --rpc-url "$RPC_URL")" == "0x" ]]; then
+  echo "[test] deployment not found on current RPC. redeploying..."
+  "$CONTRACTS_DIR/scripts/deploy-intentbook-local.sh"
+  set -a
+  source "$DEPLOY_ENV_FILE"
+  set +a
+fi
+
+cd "$CONTRACTS_DIR"
+forge script script/ExerciseIntentBookMethods.s.sol:ExerciseIntentBookMethodsScript \
+  --rpc-url "$RPC_URL" \
+  --broadcast

--- a/packages/contracts/src/mocks/MockSnapshotBook.sol
+++ b/packages/contracts/src/mocks/MockSnapshotBook.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+contract MockSnapshotBook {
+    mapping(bytes32 => bool) public finalized;
+
+    function setFinalized(bytes32 snapshotHash, bool isFinalized) external {
+        finalized[snapshotHash] = isFinalized;
+    }
+
+    function isSnapshotFinalized(bytes32 snapshotHash) external view returns (bool) {
+        return finalized[snapshotHash];
+    }
+}


### PR DESCRIPTION
## Summary
- add local deployment script for `IntentBook` + `MockSnapshotBook`
- add onchain method exercise script that covers admin setup, propose, attest, and state checks
- add Foundry script contracts used by the shell scripts
- ignore local deployment env artifact and document local workflow in contracts README

## Why
- we need a repeatable local path to deploy and verify IntentBook behavior method-by-method before wiring vault/execution layers

## How
- added:
  - `/Users/ham-yunsig/Documents/github/claw-validation-market/packages/contracts/src/mocks/MockSnapshotBook.sol`
  - `/Users/ham-yunsig/Documents/github/claw-validation-market/packages/contracts/script/DeployIntentBook.s.sol`
  - `/Users/ham-yunsig/Documents/github/claw-validation-market/packages/contracts/script/ExerciseIntentBookMethods.s.sol`
  - `/Users/ham-yunsig/Documents/github/claw-validation-market/packages/contracts/scripts/deploy-intentbook-local.sh`
  - `/Users/ham-yunsig/Documents/github/claw-validation-market/packages/contracts/scripts/test-intentbook-methods-local.sh`
- updated:
  - `/Users/ham-yunsig/Documents/github/claw-validation-market/packages/contracts/README.md`
  - `/Users/ham-yunsig/Documents/github/claw-validation-market/.gitignore`

## Testing
- [ ] Not needed (docs-only)
- [x] Unit tests added/updated
- [x] Manual test performed

Manual checks:
- `cd /Users/ham-yunsig/Documents/github/claw-validation-market/packages/contracts && forge test -vv`
- `./packages/contracts/scripts/deploy-intentbook-local.sh`
- `./packages/contracts/scripts/test-intentbook-methods-local.sh`

## Checklist
- [x] Linked issue(s) (e.g., Fixes #123)
- [x] No secrets committed
- [x] Docs updated if behavior changed

Refs #6
