### PR TITLE
Relayer v0: move canonical flow into SDK and wire core fund APIs

### DIFF
--- a/packages/relayer/app/api/v1/funds/[fundId]/claims/route.ts
+++ b/packages/relayer/app/api/v1/funds/[fundId]/claims/route.ts
@@ -1,5 +1,15 @@
 import { NextResponse } from "next/server";
 import { requireBotAuth } from "@/lib/bot-auth";
+import {
+  buildCanonicalClaimRecord,
+  type ClaimPayload
+} from "@claw/protocol-sdk";
+import {
+  getFund,
+  insertClaim,
+  listClaimsByFund,
+  upsertSubjectState
+} from "@/lib/sqlite";
 
 export async function POST(
   request: Request,
@@ -11,32 +21,146 @@ export async function POST(
     return botAuth.response;
   }
 
+  const fund = getFund(fundId);
+  if (!fund) {
+    return NextResponse.json(
+      { error: "NOT_FOUND", message: `fund not found: ${fundId}` },
+      { status: 404 }
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "BAD_REQUEST", message: "invalid json body" }, { status: 400 });
+  }
+
+  const claimPayload = (body.claimPayload ?? body.payload) as ClaimPayload | undefined;
+  const epochIdRaw = body.epochId ?? body.epoch_id;
+  const epochId = BigInt(String(epochIdRaw ?? "0"));
+
+  if (!claimPayload) {
+    return NextResponse.json(
+      { error: "BAD_REQUEST", message: "claimPayload is required" },
+      { status: 400 }
+    );
+  }
+
+  let record;
+  try {
+    record = buildCanonicalClaimRecord({
+      payload: claimPayload,
+      epochId
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: "BAD_REQUEST",
+        message: error instanceof Error ? error.message : String(error)
+      },
+      { status: 400 }
+    );
+  }
+
+  const inserted = insertClaim({
+    fundId,
+    claimHash: record.claimHash,
+    epochId: record.epochId,
+    payloadJson: JSON.stringify(record.payload),
+    createdBy: botAuth.botId
+  });
+
+  if (!inserted.ok) {
+    return NextResponse.json(
+      {
+        error: "CONFLICT",
+        message: "duplicate claimHash",
+        claimHash: record.claimHash
+      },
+      { status: 409 }
+    );
+  }
+
+  upsertSubjectState({
+    fundId,
+    subjectType: "CLAIM",
+    subjectHash: record.claimHash,
+    epochId: record.epochId,
+    thresholdWeight: BigInt(fund.verifier_threshold_weight)
+  });
+
   return NextResponse.json(
     {
-      status: "TODO",
+      status: "OK",
       endpoint: "POST /api/v1/funds/{fundId}/claims",
       fundId,
       botId: botAuth.botId,
-      message:
-        "Claim submission API baseline is scaffolded. Implement schema validation, canonical hashing, persistence, and onchain submit flow."
+      epochId: record.epochId.toString(),
+      claimHash: record.claimHash
     },
-    { status: 501 }
+    { status: 200 }
   );
 }
 
 export async function GET(
-  _request: Request,
+  request: Request,
   context: { params: Promise<{ fundId: string }> }
 ) {
   const { fundId } = await context.params;
+  const url = new URL(request.url);
+  const statusRaw = (url.searchParams.get("status") ?? "").toUpperCase();
+  const epochIdRaw = url.searchParams.get("epochId");
+  const limit = Math.min(Number(url.searchParams.get("limit") ?? "20"), 100);
+  const offset = Math.max(Number(url.searchParams.get("offset") ?? "0"), 0);
+
+  const status =
+    statusRaw === "PENDING" || statusRaw === "APPROVED" || statusRaw === "REJECTED"
+      ? statusRaw
+      : undefined;
+
+  let epochId: bigint | undefined;
+  if (epochIdRaw) {
+    try {
+      epochId = BigInt(epochIdRaw);
+    } catch {
+      return NextResponse.json(
+        { error: "BAD_REQUEST", message: "epochId must be an integer" },
+        { status: 400 }
+      );
+    }
+  }
+
+  const result = listClaimsByFund({
+    fundId,
+    status: status as "PENDING" | "APPROVED" | "REJECTED" | undefined,
+    epochId,
+    limit: Number.isFinite(limit) && limit > 0 ? limit : 20,
+    offset: Number.isFinite(offset) ? offset : 0
+  });
+
   return NextResponse.json(
     {
-      status: "TODO",
+      status: "OK",
       endpoint: "GET /api/v1/funds/{fundId}/claims",
       fundId,
-      message:
-        "Claim read API baseline is scaffolded. Implement filters (status, token, epoch) and pagination."
+      claims: result.rows.map((row) => ({
+        id: row.id,
+        claimHash: row.claim_hash,
+        epochId: row.epoch_id,
+        status: row.status,
+        attestedWeight: row.attested_weight,
+        thresholdWeight: row.threshold_weight,
+        attestationCount: row.attestation_count,
+        payload: JSON.parse(row.payload_json),
+        createdBy: row.created_by,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at
+      })),
+      total: result.total,
+      limit,
+      offset
     },
-    { status: 501 }
+    { status: 200 }
   );
 }

--- a/packages/relayer/app/api/v1/funds/[fundId]/intents/propose/route.ts
+++ b/packages/relayer/app/api/v1/funds/[fundId]/intents/propose/route.ts
@@ -1,5 +1,17 @@
 import { NextResponse } from "next/server";
 import { requireBotAuth } from "@/lib/bot-auth";
+import {
+  buildIntentAllowlistHashFromRoute,
+  buildCanonicalIntentRecord,
+  type IntentExecutionRouteInput,
+  type TradeIntent
+} from "@claw/protocol-sdk";
+import {
+  getFund,
+  getLatestSnapshot,
+  insertIntent,
+  upsertSubjectState
+} from "@/lib/sqlite";
 
 export async function POST(
   request: Request,
@@ -11,15 +23,211 @@ export async function POST(
     return botAuth.response;
   }
 
+  const fund = getFund(fundId);
+  if (!fund) {
+    return NextResponse.json(
+      { error: "NOT_FOUND", message: `fund not found: ${fundId}` },
+      { status: 404 }
+    );
+  }
+
+  if (fund.strategy_bot_id !== botAuth.botId) {
+    return NextResponse.json(
+      {
+        error: "FORBIDDEN",
+        message: "only strategy bot can propose intents",
+        expectedStrategyBotId: fund.strategy_bot_id,
+        callerBotId: botAuth.botId
+      },
+      { status: 403 }
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json(
+      { error: "BAD_REQUEST", message: "invalid json body" },
+      { status: 400 }
+    );
+  }
+
+  const intent = (body.intent ?? body.tradeIntent) as TradeIntent | undefined;
+  const providedAllowlistHash = body.allowlistHash
+    ? (String(body.allowlistHash) as `0x${string}`)
+    : null;
+  const executionRoute = body.executionRoute as
+    | Record<string, unknown>
+    | undefined;
+  const intentUri = body.intentURI ? String(body.intentURI) : null;
+
+  if (!intent) {
+    return NextResponse.json(
+      { error: "BAD_REQUEST", message: "intent is required" },
+      { status: 400 }
+    );
+  }
+  if (!providedAllowlistHash && !executionRoute) {
+    return NextResponse.json(
+      {
+        error: "BAD_REQUEST",
+        message: "allowlistHash or executionRoute is required"
+      },
+      { status: 400 }
+    );
+  }
+
+  const latestSnapshot = getLatestSnapshot(fundId);
+  if (!latestSnapshot) {
+    return NextResponse.json(
+      { error: "BAD_REQUEST", message: "no finalized snapshot available for fund" },
+      { status: 400 }
+    );
+  }
+
+  if (String(intent.snapshotHash).toLowerCase() !== latestSnapshot.snapshot_hash.toLowerCase()) {
+    return NextResponse.json(
+      {
+        error: "BAD_REQUEST",
+        message: "snapshotHash mismatch with latest finalized snapshot",
+        expectedSnapshotHash: latestSnapshot.snapshot_hash,
+        receivedSnapshotHash: intent.snapshotHash
+      },
+      { status: 400 }
+    );
+  }
+
+  let computedAllowlistHash: `0x${string}` | null = null;
+  if (executionRoute) {
+    try {
+      const route: IntentExecutionRouteInput = {
+        tokenIn: String(executionRoute.tokenIn) as `0x${string}`,
+        tokenOut: String(executionRoute.tokenOut) as `0x${string}`,
+        quoteAmountOut: BigInt(String(executionRoute.quoteAmountOut)),
+        minAmountOut: BigInt(String(executionRoute.minAmountOut)),
+        adapter: String(executionRoute.adapter) as `0x${string}`,
+        adapterData: executionRoute.adapterData
+          ? (String(executionRoute.adapterData) as `0x${string}`)
+          : undefined,
+        adapterDataHash: executionRoute.adapterDataHash
+          ? (String(executionRoute.adapterDataHash) as `0x${string}`)
+          : undefined
+      };
+
+      if (
+        route.tokenIn.toLowerCase() !== intent.tokenIn.toLowerCase() ||
+        route.tokenOut.toLowerCase() !== intent.tokenOut.toLowerCase() ||
+        route.minAmountOut !== intent.minAmountOut
+      ) {
+        return NextResponse.json(
+          {
+            error: "BAD_REQUEST",
+            message:
+              "executionRoute tokenIn/tokenOut/minAmountOut must match intent"
+          },
+          { status: 400 }
+        );
+      }
+
+      computedAllowlistHash = buildIntentAllowlistHashFromRoute(route);
+    } catch (error) {
+      return NextResponse.json(
+        {
+          error: "BAD_REQUEST",
+          message:
+            error instanceof Error
+              ? `invalid executionRoute: ${error.message}`
+              : "invalid executionRoute"
+        },
+        { status: 400 }
+      );
+    }
+  }
+
+  if (
+    providedAllowlistHash &&
+    computedAllowlistHash &&
+    providedAllowlistHash.toLowerCase() !== computedAllowlistHash.toLowerCase()
+  ) {
+    return NextResponse.json(
+      {
+        error: "BAD_REQUEST",
+        message: "allowlistHash mismatch with computed executionRoute hash",
+        providedAllowlistHash,
+        computedAllowlistHash
+      },
+      { status: 400 }
+    );
+  }
+
+  const allowlistHash =
+    (computedAllowlistHash ?? providedAllowlistHash) as `0x${string}`;
+
+  let built;
+  try {
+    built = buildCanonicalIntentRecord({
+      intent,
+      allowlistHash,
+      maxNotional: body.maxNotional ? BigInt(String(body.maxNotional)) : intent.amountIn
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: "BAD_REQUEST",
+        message: error instanceof Error ? error.message : String(error)
+      },
+      { status: 400 }
+    );
+  }
+
+  const inserted = insertIntent({
+    fundId,
+    intentHash: built.intentHash,
+    snapshotHash: built.intent.snapshotHash,
+    intentUri,
+    intentJson: JSON.stringify(built.intent),
+    allowlistHash: built.constraints.allowlistHash,
+    maxSlippageBps: built.constraints.maxSlippageBps,
+    maxNotional: built.constraints.maxNotional,
+    deadline: built.constraints.deadline,
+    createdBy: botAuth.botId
+  });
+
+  if (!inserted.ok) {
+    return NextResponse.json(
+      {
+        error: "CONFLICT",
+        message: "duplicate intentHash",
+        intentHash: built.intentHash
+      },
+      { status: 409 }
+    );
+  }
+
+  upsertSubjectState({
+    fundId,
+    subjectType: "INTENT",
+    subjectHash: built.intentHash,
+    epochId: BigInt(latestSnapshot.epoch_id),
+    thresholdWeight: BigInt(fund.intent_threshold_weight)
+  });
+
   return NextResponse.json(
     {
-      status: "TODO",
+      status: "OK",
       endpoint: "POST /api/v1/funds/{fundId}/intents/propose",
-      fundId: fundId,
+      fundId,
       botId: botAuth.botId,
-      message:
-        "Intent proposal API baseline is scaffolded. Implement snapshot linkage checks, risk-constraint checks, and intentHash persistence."
+      intentHash: built.intentHash,
+      snapshotHash: built.intent.snapshotHash,
+      constraints: {
+        allowlistHash: built.constraints.allowlistHash,
+        maxSlippageBps: built.constraints.maxSlippageBps.toString(),
+        maxNotional: built.constraints.maxNotional.toString(),
+        deadline: built.constraints.deadline.toString()
+      }
     },
-    { status: 501 }
+    { status: 200 }
   );
 }

--- a/packages/relayer/lib/validator-snapshot.ts
+++ b/packages/relayer/lib/validator-snapshot.ts
@@ -5,6 +5,7 @@ import {
   type ValidatorWeight
 } from "@claw/protocol-sdk";
 import { loadRuntimeConfig } from "@/lib/config";
+import { getFundThresholds } from "@/lib/sqlite";
 
 export interface ValidatorSnapshot {
   snapshotId: string;
@@ -39,14 +40,18 @@ function snapshotFromConfig(snapshotId: string, thresholdWeight: bigint): Valida
 
 export function loadClaimValidatorSnapshot(fundId: string, epochId: bigint): ValidatorSnapshot {
   const cfg = loadRuntimeConfig();
+  const fund = getFundThresholds(fundId);
+  const thresholdWeight = fund?.claimThresholdWeight ?? cfg.claimThresholdWeight;
   // TODO: replace config-backed snapshot with onchain snapshot reader once registry ABI is finalized.
-  return snapshotFromConfig(`${fundId}:${epochId.toString()}:claim`, cfg.claimThresholdWeight);
+  return snapshotFromConfig(`${fundId}:${epochId.toString()}:claim`, thresholdWeight);
 }
 
 export function loadIntentValidatorSnapshot(fundId: string): ValidatorSnapshot {
   const cfg = loadRuntimeConfig();
+  const fund = getFundThresholds(fundId);
+  const thresholdWeight = fund?.intentThresholdWeight ?? cfg.intentThresholdWeight;
   // TODO: replace config-backed snapshot with onchain snapshot reader once registry ABI is finalized.
-  return snapshotFromConfig(`${fundId}:intent`, cfg.intentThresholdWeight);
+  return snapshotFromConfig(`${fundId}:intent`, thresholdWeight);
 }
 
 export function verifierWeight(snapshot: ValidatorSnapshot, verifier: Address): bigint {

--- a/packages/relayer/next-env.d.ts
+++ b/packages/relayer/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -10,3 +10,4 @@ export * from "./validate.js";
 export * from "./attestation-verifier.js";
 export * from "./weighted-attestation.js";
 export * from "./execution-data.js";
+export * from "./relayer-utils.js";

--- a/packages/sdk/src/relayer-utils.ts
+++ b/packages/sdk/src/relayer-utils.ts
@@ -1,0 +1,136 @@
+import { keccak256 } from "viem";
+import { canonicalClaim, canonicalIntent } from "./canonical.js";
+import {
+  claimHash,
+  intentExecutionAllowlistHash,
+  intentHash,
+  snapshotHashFromUnordered
+} from "./hash.js";
+import type {
+  CanonicalClaimRecord,
+  CanonicalIntentRecord,
+  ClaimPayload,
+  Hex,
+  IntentExecutionRouteInput,
+  IntentConstraints,
+  TradeIntent
+} from "./types.js";
+import { assertUint16, assertUint64 } from "./validate.js";
+
+function assertPositive(value: bigint, label: string): void {
+  if (value <= 0n) {
+    throw new Error(`${label} must be positive`);
+  }
+}
+
+function assertHex32(value: string, label: string): asserts value is Hex {
+  if (!/^0x[0-9a-fA-F]{64}$/.test(value)) {
+    throw new Error(`${label} must be 0x-prefixed 32-byte hex`);
+  }
+}
+
+export function buildCanonicalClaimRecord(input: {
+  payload: ClaimPayload;
+  epochId: bigint;
+}): CanonicalClaimRecord {
+  assertUint64(input.epochId, "epochId");
+  assertUint64(input.payload.timestamp, "timestamp");
+
+  const payload = canonicalClaim(input.payload);
+  const hash = claimHash(payload);
+
+  return {
+    payload,
+    epochId: input.epochId,
+    claimHash: hash
+  };
+}
+
+export function buildIntentConstraints(input: {
+  allowlistHash: Hex;
+  maxSlippageBps: bigint;
+  maxNotional: bigint;
+  deadline: bigint;
+}): IntentConstraints {
+  assertHex32(input.allowlistHash, "allowlistHash");
+  assertUint16(input.maxSlippageBps, "maxSlippageBps");
+  assertUint64(input.deadline, "deadline");
+  assertPositive(input.maxNotional, "maxNotional");
+
+  return {
+    allowlistHash: input.allowlistHash,
+    maxSlippageBps: input.maxSlippageBps,
+    maxNotional: input.maxNotional,
+    deadline: input.deadline
+  };
+}
+
+export function buildCanonicalIntentRecord(input: {
+  intent: TradeIntent;
+  allowlistHash: Hex;
+  maxNotional: bigint;
+  now?: bigint;
+}): CanonicalIntentRecord {
+  const intent = canonicalIntent(input.intent);
+  assertUint64(intent.deadline, "deadline");
+  assertUint16(intent.maxSlippageBps, "maxSlippageBps");
+  assertPositive(intent.amountIn, "amountIn");
+  assertPositive(intent.minAmountOut, "minAmountOut");
+
+  if (intent.deadline <= (input.now ?? BigInt(Math.floor(Date.now() / 1000)))) {
+    throw new Error("intent deadline is expired");
+  }
+
+  const constraints = buildIntentConstraints({
+    allowlistHash: input.allowlistHash,
+    maxSlippageBps: intent.maxSlippageBps,
+    maxNotional: input.maxNotional,
+    deadline: intent.deadline
+  });
+
+  return {
+    intent,
+    intentHash: intentHash(intent),
+    constraints
+  };
+}
+
+export function buildCanonicalSnapshotRecord(input: {
+  epochId: bigint;
+  claimHashes: Hex[];
+}) {
+  assertUint64(input.epochId, "epochId");
+  if (input.claimHashes.length === 0) {
+    throw new Error("claimHashes must not be empty");
+  }
+
+  const hash = snapshotHashFromUnordered(input.epochId, input.claimHashes);
+  return {
+    epochId: input.epochId,
+    snapshotHash: hash
+  };
+}
+
+export function buildIntentAllowlistHashFromRoute(
+  route: IntentExecutionRouteInput
+): Hex {
+  assertPositive(route.quoteAmountOut, "quoteAmountOut");
+  assertPositive(route.minAmountOut, "minAmountOut");
+
+  const adapterDataHash =
+    route.adapterDataHash ??
+    (route.adapterData ? keccak256(route.adapterData) : undefined);
+  if (!adapterDataHash) {
+    throw new Error("adapterData or adapterDataHash is required");
+  }
+  assertHex32(adapterDataHash, "adapterDataHash");
+
+  return intentExecutionAllowlistHash(
+    route.tokenIn,
+    route.tokenOut,
+    route.quoteAmountOut,
+    route.minAmountOut,
+    route.adapter,
+    adapterDataHash
+  );
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -82,3 +82,32 @@ export interface NadfunExecutionDataV1 {
   amountOutMin: bigint;
   extra: Hex;
 }
+
+export interface IntentConstraints {
+  allowlistHash: Hex;
+  maxSlippageBps: bigint;
+  maxNotional: bigint;
+  deadline: bigint;
+}
+
+export interface IntentExecutionRouteInput {
+  tokenIn: Address;
+  tokenOut: Address;
+  quoteAmountOut: bigint;
+  minAmountOut: bigint;
+  adapter: Address;
+  adapterData?: Hex;
+  adapterDataHash?: Hex;
+}
+
+export interface CanonicalClaimRecord {
+  payload: ClaimPayload;
+  epochId: bigint;
+  claimHash: Hex;
+}
+
+export interface CanonicalIntentRecord {
+  intent: TradeIntent;
+  intentHash: Hex;
+  constraints: IntentConstraints;
+}

--- a/packages/sdk/test/relayer-utils.test.mjs
+++ b/packages/sdk/test/relayer-utils.test.mjs
@@ -1,0 +1,104 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildCanonicalClaimRecord,
+  buildCanonicalIntentRecord,
+  buildCanonicalSnapshotRecord,
+  buildIntentAllowlistHashFromRoute,
+  intentExecutionCallHash
+} from "../dist/index.js";
+
+test("buildCanonicalClaimRecord normalizes claim and hashes", () => {
+  const out = buildCanonicalClaimRecord({
+    payload: {
+      schemaId: " score_v1 ",
+      sourceType: " WEB ",
+      sourceRef: " https://example.com ",
+      selector: " .score ",
+      extracted: " 123 ",
+      extractedType: " uint ",
+      timestamp: 100n,
+      responseHash: "0x1111111111111111111111111111111111111111111111111111111111111111",
+      evidenceType: " recrawl ",
+      evidenceURI: " ipfs://abc ",
+      crawler: "0x00000000000000000000000000000000000000a1"
+    },
+    epochId: 1n
+  });
+
+  assert.equal(out.payload.schemaId, "score_v1");
+  assert.equal(out.epochId, 1n);
+  assert.equal(out.claimHash.startsWith("0x"), true);
+});
+
+test("buildCanonicalIntentRecord validates deadline and constraints", () => {
+  const out = buildCanonicalIntentRecord({
+    intent: {
+      intentVersion: " v1 ",
+      vault: "0x00000000000000000000000000000000000000a1",
+      action: "buy",
+      tokenIn: "0x00000000000000000000000000000000000000b2",
+      tokenOut: "0x00000000000000000000000000000000000000c3",
+      amountIn: 1000n,
+      minAmountOut: 900n,
+      deadline: 9999999999n,
+      maxSlippageBps: 300n,
+      snapshotHash: "0x2222222222222222222222222222222222222222222222222222222222222222"
+    },
+    allowlistHash: "0x3333333333333333333333333333333333333333333333333333333333333333",
+    maxNotional: 1000n,
+    now: 1n
+  });
+
+  assert.equal(out.intent.action, "BUY");
+  assert.equal(out.constraints.maxSlippageBps, 300n);
+  assert.equal(out.intentHash.startsWith("0x"), true);
+});
+
+test("buildCanonicalSnapshotRecord rejects empty claim hashes", () => {
+  assert.throws(
+    () =>
+      buildCanonicalSnapshotRecord({
+        epochId: 1n,
+        claimHashes: []
+      }),
+    /must not be empty/
+  );
+});
+
+test("buildIntentAllowlistHashFromRoute matches direct call hash", () => {
+  const route = {
+    tokenIn: "0x00000000000000000000000000000000000000a1",
+    tokenOut: "0x00000000000000000000000000000000000000b2",
+    quoteAmountOut: 1000n,
+    minAmountOut: 980n,
+    adapter: "0x00000000000000000000000000000000000000c3",
+    adapterData: "0x12345678"
+  };
+
+  const fromRoute = buildIntentAllowlistHashFromRoute(route);
+  const direct = intentExecutionCallHash(
+    route.tokenIn,
+    route.tokenOut,
+    route.quoteAmountOut,
+    route.minAmountOut,
+    route.adapter,
+    route.adapterData
+  );
+
+  assert.equal(fromRoute, direct);
+});
+
+test("buildIntentAllowlistHashFromRoute requires adapterData*", () => {
+  assert.throws(
+    () =>
+      buildIntentAllowlistHashFromRoute({
+        tokenIn: "0x00000000000000000000000000000000000000a1",
+        tokenOut: "0x00000000000000000000000000000000000000b2",
+        quoteAmountOut: 1000n,
+        minAmountOut: 980n,
+        adapter: "0x00000000000000000000000000000000000000c3"
+      }),
+    /adapterData/
+  );
+});


### PR DESCRIPTION
## Summary
- move claim/intent/snapshot canonicalization and validation helpers into `@claw/protocol-sdk`
- implement relayer v0 fund APIs for claims submit/list, snapshot latest, and intents propose
- enforce strategy-bot-only intent proposal and snapshot-hash consistency checks
- support route-based intent constraints for `allowlistHash` generation path
- align weighted threshold loading with fund-specific DB config (fallback to env)

## Why
- relayer logic was fragmented and partially TODO, making the claim -> snapshot -> intent flow unreliable
- canonical logic should be shared and testable in SDK, then consumed by relayer/api/contracts consistently
- intent proposal needs deterministic constraints aligned with onchain `ClawCore` execution validation

## How
- added SDK relayer utilities:
  - `buildCanonicalClaimRecord`
  - `buildCanonicalSnapshotRecord`
  - `buildIntentConstraints`
  - `buildCanonicalIntentRecord`
  - `buildIntentAllowlistHashFromRoute`
- implemented relayer endpoints:
  - `POST/GET /api/v1/funds/{fundId}/claims`
  - `GET /api/v1/funds/{fundId}/snapshots/latest`
  - `POST /api/v1/funds/{fundId}/intents/propose`
- extended sqlite layer for claim/intent/snapshot persistence and status transitions
- switched validator threshold source to fund DB values first

## Testing
- [ ] Not needed (docs-only)
- [x] Unit tests added/updated
- [x] Manual test performed

Manual checks:
- `npm test -w @claw/protocol-sdk` (pass)
- `npm run build -w @claw/relayer` (pass)
- `forge test -q` (pass, baseline compatibility check)

## Checklist
- [x] Linked issue(s) (e.g., Fixes #123)
- [x] No secrets committed
- [ ] Docs updated if behavior changed

Refs #8 #31 #32 #33 #35
