### PR TITLE
relayer: DB-backed bot credentials + docs/skills alignment

### DIFF
--- a/agent-threat-model.md
+++ b/agent-threat-model.md
@@ -123,7 +123,7 @@ flowchart LR
 | Asset | Why it matters | Security objective (C/I/A) |
 | --- | --- | --- |
 | Fund intent/claim state (`subject_state`, `intents`, `claims`) | Drives approval/execution lifecycle and room decisions | I, A |
-| Bot credentials (`BOT_API_KEYS`, bot scopes) | Gatekeeper for all bot write APIs | C, I |
+| Bot credentials (Supabase `bot_credentials`, env fallback `BOT_API_KEYS`/scopes) | Gatekeeper for all bot write APIs | C, I |
 | Admin credentials/session | Control fund bootstrap and strategy bot identity | C, I |
 | Onchain ownership and upgrade authority | Can alter executor/core/vault logic and policy gates | I |
 | Execution route payload (`adapterData`, allowlist hash linkage) | Controls actual trade venue and settlement constraints | I |

--- a/docs/prompts/kr/participant_moltbot.md
+++ b/docs/prompts/kr/participant_moltbot.md
@@ -3,148 +3,120 @@
 아래 프롬프트는 `docs/prompts/kr/base_system.md`를 먼저 붙인 뒤 사용한다.
 
 ## Role
-Participant MoltBot (Miner + Verifier)
+Participant MoltBot (Allocation Proposer + Validator)
 
 ## Objective
-- 지정된 SourceSpec으로 데이터를 채굴(Observation)한다.
-- 동일 대상을 교차 검증하고 Attestation을 생성한다.
-- Intent 단계에서는 기술 검증(validity)과 사용자 가치판단(judgment vote)을 분리해 제출한다.
-- 정산 이전 단계에서 신뢰 가능한 서명 자료를 Relayer에 전달한다.
+- 참여자는 데이터 마이닝이 아니라 `AllocationClaimV1` 기반 목표 비중 claim을 제출한다.
+- claim/intent는 스키마, 스코프, canonical hash 재현 기준으로 검증한다.
+- 릴레이어 제출은 explicit submit safety gate를 통과한 경우에만 수행한다.
 
-## Mode A: Mining
+## Supported Tasks (Only)
+- `propose_allocation`
+- `validate_allocation_or_intent`
+- `submit_allocation`
 
-### Input
+## Input/Output Contract
+
+### 1) propose_allocation
+입력:
 ```json
 {
-  "taskType": "mine_claim",
+  "taskType": "propose_allocation",
   "fundId": "fund-001",
-  "roomId": "telegram-room-abc",
+  "roomId": "room-001",
   "epochId": 12,
-  "sourceSpec": {
-    "sourceSpecId": "NADFUN_TOKEN_ACTIVITY_V1",
-    "sourceRef": "https://...",
-    "extractor": {},
-    "freshnessSeconds": 600
-  },
-  "tokenContext": {
-    "symbol": "ABC",
-    "address": "0x..."
+  "allocation": {
+    "participant": "0x...",
+    "targetWeights": ["7000", "3000"],
+    "horizonSec": 3600,
+    "nonce": 1739000000
   }
 }
 ```
 
-### Output
+출력:
 ```json
 {
   "status": "OK",
-  "taskType": "mine_claim",
+  "taskType": "propose_allocation",
   "fundId": "fund-001",
   "epochId": 12,
   "observation": {
-    "sourceSpecId": "NADFUN_TOKEN_ACTIVITY_V1",
-    "token": "0x...",
-    "timestamp": 1739000000,
-    "extracted": "12345",
-    "responseHash": "0x...",
-    "evidenceURI": "ipfs://...",
-    "crawler": "0xCrawler"
-  },
-  "confidence": 0.84,
-  "assumptions": []
+    "claimHash": "0x...",
+    "canonicalClaim": {
+      "claimVersion": "v1",
+      "fundId": "fund-001",
+      "epochId": "12",
+      "participant": "0x...",
+      "targetWeights": ["7000", "3000"],
+      "horizonSec": "3600",
+      "nonce": "1739000000",
+      "submittedAt": "1739000001"
+    }
+  }
 }
 ```
 
-## Mode B: Verification
-
-### Input
+### 2) validate_allocation_or_intent
+입력:
 ```json
 {
-  "taskType": "verify_claim_or_intent_validity",
+  "taskType": "validate_allocation_or_intent",
   "fundId": "fund-001",
-  "roomId": "telegram-room-abc",
+  "roomId": "room-001",
   "epochId": 12,
   "subjectType": "CLAIM | INTENT",
   "subjectHash": "0x...",
   "subjectPayload": {},
   "validationPolicy": {
     "reproducible": true,
-    "maxDataAgeSeconds": 900
+    "maxDataAgeSeconds": 300
   }
 }
 ```
 
-### Output
+출력:
 ```json
 {
   "status": "OK",
-  "taskType": "verify_claim_or_intent_validity",
+  "taskType": "validate_allocation_or_intent",
   "fundId": "fund-001",
-  "roomId": "telegram-room-abc",
+  "roomId": "room-001",
   "epochId": 12,
   "subjectType": "CLAIM",
   "subjectHash": "0x...",
-  "verdict": "PASS",
-  "reason": "재현 결과 일치, freshness 통과",
-  "attestationDraft": {
-    "validator": "0xVerifier",
-    "expiresAt": 1739000900,
-    "nonce": 99
-  },
-  "confidence": 0.88,
-  "assumptions": []
+  "verdict": "PASS | FAIL | NEED_MORE_EVIDENCE",
+  "reasonCode": "OK | MISSING_FIELDS | INVALID_SCOPE | HASH_MISMATCH | REPRODUCTION_FAILED"
 }
 ```
 
-## Mode C: Intent Judgment Vote
-
-### Input
+### 3) submit_allocation
+입력:
 ```json
 {
-  "taskType": "vote_intent_judgment",
+  "taskType": "submit_allocation",
   "fundId": "fund-001",
-  "roomId": "telegram-room-abc",
   "epochId": 12,
-  "intentHash": "0x...",
-  "intentSummary": {
-    "action": "BUY",
-    "tokenIn": "0xUSDC",
-    "tokenOut": "0xTOKEN",
-    "amountIn": "500",
-    "maxSlippageBps": 70
-  },
-  "votePolicy": {
-    "allowedVotes": ["YES", "NO", "ABSTAIN"],
-    "requireReason": true,
-    "customPolicyRef": "user-local-policy://my-room-alpha-v2"
-  }
+  "observation": "propose_allocation output observation",
+  "submit": true
 }
 ```
 
-### Output
+출력:
 ```json
 {
   "status": "OK",
-  "taskType": "vote_intent_judgment",
   "fundId": "fund-001",
-  "roomId": "telegram-room-abc",
   "epochId": 12,
-  "intentHash": "0x...",
-  "vote": "YES",
-  "reason": "리스크 한도 내에서 기대값이 양수라고 판단",
-  "judgmentAttestationDraft": {
-    "voter": "0xParticipant",
-    "nonce": 1001,
-    "expiresAt": 1739001800
-  },
-  "confidence": 0.74,
-  "assumptions": []
+  "decision": "READY | SUBMITTED",
+  "claimHash": "0x..."
 }
 ```
 
 ## Rules
-1. 소스 재현 실패 시 PASS 금지
-2. evidenceURI/responseHash 누락 시 `NEED_MORE_EVIDENCE`
-3. subject가 현재 fund/epoch 스코프와 다르면 `REJECTED`
-4. private key는 입력받지 않고, 서명은 별도 signer 모듈에서 수행한다고 가정
-5. intent 판단 투표는 `intentHash` 단위로 식별한다.
-6. judgment는 사용자별 커스텀 정책(`customPolicyRef`)을 허용한다.
+1. `targetWeights`는 정수, 음수 금지, 합계 > 0.
+2. `targetWeights[i]`는 strategy `riskPolicy.allowlistTokens[i]`와 동일 인덱스.
+3. CLAIM 검증은 canonical hash를 재현하여 `subjectHash`와 비교.
+4. submit endpoint는 `POST /api/v1/funds/{fundId}/claims`.
+5. explicit submit safety gate 미통과 시 네트워크 전송 금지.
+6. 아래 레거시 task는 금지: `mine_claim`, `verify_claim_or_intent_validity`, `submit_mined_claim`, `attest_claim`.

--- a/packages/openfunderse/bin/openfunderse.mjs
+++ b/packages/openfunderse/bin/openfunderse.mjs
@@ -886,7 +886,8 @@ async function runBotInit(options) {
   }
 	  if (botApiKeyHashedEntry) {
 	    console.log(`Bot API key SHA-256: ${botApiKeyHash}`);
-	    console.log(`Relayer BOT_API_KEYS hashed entry: ${botApiKeyHashedEntry}`);
+	    console.log(`Relayer credential registration value (botApiKeySha256): ${botApiKeyHashedEntry.replace(/^.*:sha256:/, "")}`);
+	    console.log("Note: Prefer DB-backed relayer auth. Register this sha256 via /api/v1/funds/sync-by-strategy (strategy) or /api/v1/funds/{fundId}/bots/register (participants).");
 	  }
 	  if (syncMeta?.synced && options.restartOpenclawGateway) {
 	    console.log("Restarting OpenClaw gateway to apply env changes...");

--- a/packages/openfunderse/packs/openfunderse-participant/openfunderse-participant/SKILL.md
+++ b/packages/openfunderse/packs/openfunderse-participant/openfunderse-participant/SKILL.md
@@ -90,6 +90,21 @@ Note:
 - Always run `bot-init` before funding or running production actions.
 - `bot-init` generates a random `BOT_API_KEY` when current value is missing or placeholder.
 
+## Relayer Bot Credential Model (Important)
+
+This skill sends write requests to relayer with:
+- `x-bot-id: BOT_ID`
+- `x-bot-api-key: BOT_API_KEY`
+
+For production, relayer should validate these via **DB-backed credentials** (Supabase `bot_credentials`) instead of Vercel env `BOT_API_KEYS`.
+
+**Participant credential registration is NOT done by the participant bot.**
+It must be registered by the **strategy bot** when it registers the participant:
+- Strategy calls `POST /api/v1/funds/{fundId}/bots/register`
+- Include `botId` + `botAddress` + `botApiKeySha256` (sha256 hex from participant `bot-init`) and optional `botScopes`
+
+If the participant key is not registered, relayer will reject participant write APIs with `401`.
+
 `propose_allocation` outputs canonical allocation claim:
 - `claimVersion: "v1"`
 - `fundId`, `epochId`, `participant`
@@ -157,19 +172,17 @@ If gate is closed, return `decision=READY` (no submit).
 }
 ```
 
-## Verification rules
-
 ## Rules
 
-1. **Reproduction Requirement**: Do NOT issue a `PASS` verdict if the source data cannot be reproduced or verified.
-2. **Evidence Check**: If `evidenceURI` or `responseHash` is missing from the subject, return `NEED_MORE_EVIDENCE`.
-3. **Scope Validation**: If the subject's `fundId` or `epochId` does not match the current task context, return `FAIL`.
-4. **Key Hygiene**: Use only dedicated participant/verifier keys. Never use custody/admin keys for attest operations.
-5. **Freshness**: Adhere to `freshnessSeconds` or `maxDataAgeSeconds` constraints. If data is stale, the verdict should reflect this.
-6. **Deterministic Output**: Ensure the output is valid JSON and follows the specified schema.
-7. **Intent Judgment**: This skill focuses on technical validity (`verify_claim_or_intent_validity`). Subjective judgment voting (`vote_intent_judgment`) is excluded from this specification.
-8. **Claim Hash Integrity**: `submit_mined_claim` must reject when locally computed claim hash differs from relayer response hash.
-9. **Domain Integrity**: `attest_claim` must sign with the configured claim attestation verifier domain.
-10. **No Implicit Submit**: Do not submit/attest to relayer unless explicit submit gating is passed.
-11. **Trusted Relayer**: In production, set `PARTICIPANT_TRUSTED_RELAYER_HOSTS` and avoid arbitrary relayer URLs.
-12. **Env Source Priority**: Resolve runtime env from `/home/ubuntu/.openclaw/openclaw.json` (`env.vars`) before local `.env*` files.
+1. **Supported Tasks Only**: Use only `propose_allocation`, `validate_allocation_or_intent`, `submit_allocation`.
+2. **Schema Rule**: Claim schema is `AllocationClaimV1` only (`claimVersion`, `fundId`, `epochId`, `participant`, `targetWeights`, `horizonSec`, `nonce`, `submittedAt`).
+3. **Weights Rule**: `targetWeights` must be integer, non-negative, non-empty, and sum > 0.
+4. **Index Mapping Rule**: `targetWeights[i]` MUST map to strategy `riskPolicy.allowlistTokens[i]` in the same order.
+5. **Scope Validation**: If subject `fundId`/`epochId` differs from task scope, return `FAIL`.
+6. **Hash Validation**: For CLAIM, recompute canonical hash via SDK and compare with `subjectHash`; mismatch returns `FAIL`.
+7. **Submit Endpoint**: `submit_allocation` sends claim to relayer `POST /api/v1/funds/{fundId}/claims`.
+8. **No Implicit Submit**: Submit only when explicit submit gate is satisfied.
+9. **Trusted Relayer**: In production, set `PARTICIPANT_TRUSTED_RELAYER_HOSTS` and avoid arbitrary relayer URLs.
+10. **Key Hygiene**: Use dedicated participant keys only; never use custody/admin keys.
+11. **Env Source Priority**: Resolve runtime env from `/home/ubuntu/.openclaw/openclaw.json` (`env.vars`) before local `.env*` files.
+12. **Legacy Tasks Disabled**: Do not use `mine_claim`, `verify_claim_or_intent_validity`, `submit_mined_claim`, `attest_claim`.

--- a/packages/relayer/README.md
+++ b/packages/relayer/README.md
@@ -81,7 +81,16 @@ npm run dev -w @claw/relayer
   - 튜토리얼 페이지 접근 (`/join`)
 - `bot`:
   - write API 호출 시 `x-bot-id`, `x-bot-api-key` 필수
-  - `BOT_SCOPES`로 API scope 검증 (`claims.submit`, `intents.propose`, `intents.attest`, `bots.register`, `funds.bootstrap`)
+  - API key 검증 원천(우선순위):
+    1) Supabase `bot_credentials` (권장)
+    2) `BOT_API_KEYS`/`BOT_SCOPES` env fallback (레거시)
+  - scope 검증은 `bot_credentials.scopes` 또는 `BOT_SCOPES`로 수행 (`claims.submit`, `intents.propose`, `intents.attest`, `bots.register`, `funds.bootstrap`)
+
+### Bot credential registration (recommended)
+- Strategy bot:
+  - `POST /api/v1/funds/sync-by-strategy` 호출 시 `strategyBotApiKeySha256`(bot-init sha256 hex)을 body에 포함하면 relayer DB에 등록됩니다.
+- Participant bot:
+  - Strategy bot이 `POST /api/v1/funds/{fundId}/bots/register` 호출 시 `botApiKeySha256`(bot-init sha256 hex)을 body에 포함하면 relayer DB에 등록됩니다.
 
 ## UI routes (scaffold)
 - `/`: 일반 유저용 참여/초기 셋업 안내 메인 페이지

--- a/packages/relayer/app/api/v1/funds/[fundId]/bots/register/route.ts
+++ b/packages/relayer/app/api/v1/funds/[fundId]/bots/register/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
-import { requireBotAuth } from "@/lib/bot-auth";
+import { requireBotAuthAsync } from "@/lib/bot-auth";
 import { getFund, listFundBots, upsertFundBot } from "@/lib/supabase";
+import { upsertBotCredential } from "@/lib/supabase";
 
 const ALLOWED_ROLES = new Set(["participant"]);
 
@@ -9,7 +10,7 @@ export async function POST(
   context: { params: Promise<{ fundId: string }> }
 ) {
   const { fundId } = await context.params;
-  const botAuth = requireBotAuth(request, ["bots.register"]);
+  const botAuth = await requireBotAuthAsync(request, ["bots.register"]);
   if (!botAuth.ok) {
     return botAuth.response;
   }
@@ -24,6 +25,9 @@ export async function POST(
   const role = String(body.role ?? "").trim().toLowerCase();
   const botId = String(body.botId ?? "").trim();
   const botAddress = String(body.botAddress ?? "").trim();
+  const botApiKey = String(body.botApiKey ?? "").trim();
+  const botApiKeySha256 = String(body.botApiKeySha256 ?? "").trim().toLowerCase();
+  const botScopes = String(body.botScopes ?? "").trim();
 
   if (!ALLOWED_ROLES.has(role)) {
     return NextResponse.json(
@@ -78,6 +82,18 @@ export async function POST(
     registeredBy: botAuth.botId
   });
 
+  // Optional: register participant bot credentials in DB so relayer auth doesn't depend on deploy-time env.
+  // Prefer sending botApiKeySha256 from `bot-init` output.
+  if (botApiKeySha256 || botApiKey) {
+    const apiKeyValue = botApiKeySha256 ? `sha256:${botApiKeySha256}` : botApiKey;
+    await upsertBotCredential({
+      botId,
+      apiKey: apiKeyValue,
+      scopes: botScopes,
+      createdBy: botAuth.botId
+    });
+  }
+
   return NextResponse.json(
     {
       status: "OK",
@@ -102,7 +118,7 @@ export async function GET(
   context: { params: Promise<{ fundId: string }> }
 ) {
   const { fundId } = await context.params;
-  const botAuth = requireBotAuth(request, ["bots.register"]);
+  const botAuth = await requireBotAuthAsync(request, ["bots.register"]);
   if (!botAuth.ok) {
     return botAuth.response;
   }

--- a/packages/relayer/app/api/v1/funds/[fundId]/claims/route.ts
+++ b/packages/relayer/app/api/v1/funds/[fundId]/claims/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireBotAuth } from "@/lib/bot-auth";
+import { requireBotAuthAsync } from "@/lib/bot-auth";
 import { isSameAddress, requireFundBotRole } from "@/lib/fund-bot-authz";
 import {
   buildCanonicalAllocationClaimRecord,
@@ -16,7 +16,7 @@ export async function POST(
   context: { params: Promise<{ fundId: string }> }
 ) {
   const { fundId } = await context.params;
-  const botAuth = requireBotAuth(request, ["claims.submit"]);
+  const botAuth = await requireBotAuthAsync(request, ["claims.submit"]);
   if (!botAuth.ok) {
     return botAuth.response;
   }

--- a/packages/relayer/app/api/v1/funds/[fundId]/epochs/[epochId]/aggregate/route.ts
+++ b/packages/relayer/app/api/v1/funds/[fundId]/epochs/[epochId]/aggregate/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireBotAuth } from "@/lib/bot-auth";
+import { requireBotAuthAsync } from "@/lib/bot-auth";
 import { requireFundBotRole } from "@/lib/fund-bot-authz";
 import { buildEpochStateRecord, type Hex } from "@claw/protocol-sdk";
 import {
@@ -37,7 +37,7 @@ export async function POST(
 ) {
   const { fundId, epochId } = await context.params;
 
-  const botAuth = requireBotAuth(_request, ["intents.propose"]);
+  const botAuth = await requireBotAuthAsync(_request, ["intents.propose"]);
   if (!botAuth.ok) {
     return botAuth.response;
   }

--- a/packages/relayer/app/api/v1/funds/[fundId]/intents/[intentHash]/onchain-attested/route.ts
+++ b/packages/relayer/app/api/v1/funds/[fundId]/intents/[intentHash]/onchain-attested/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireBotAuth } from "@/lib/bot-auth";
+import { requireBotAuthAsync } from "@/lib/bot-auth";
 import { requireFundBotRole } from "@/lib/fund-bot-authz";
 import { getSubjectStateByFund, markSubjectApproved } from "@/lib/supabase";
 
@@ -17,7 +17,7 @@ export async function POST(
   context: { params: Promise<{ fundId: string; intentHash: string }> }
 ) {
   const { fundId, intentHash } = await context.params;
-  const botAuth = requireBotAuth(request, ["intents.propose"]);
+  const botAuth = await requireBotAuthAsync(request, ["intents.propose"]);
   if (!botAuth.ok) {
     return botAuth.response;
   }

--- a/packages/relayer/app/api/v1/funds/[fundId]/intents/[intentHash]/onchain-bundle/route.ts
+++ b/packages/relayer/app/api/v1/funds/[fundId]/intents/[intentHash]/onchain-bundle/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireBotAuth } from "@/lib/bot-auth";
+import { requireBotAuthAsync } from "@/lib/bot-auth";
 import { requireFundBotRole } from "@/lib/fund-bot-authz";
 import { getIntentAttestationBundle } from "@/lib/supabase";
 
@@ -8,7 +8,7 @@ export async function GET(
   context: { params: Promise<{ fundId: string; intentHash: string }> }
 ) {
   const { fundId, intentHash } = await context.params;
-  const botAuth = requireBotAuth(request, ["intents.propose"]);
+  const botAuth = await requireBotAuthAsync(request, ["intents.propose"]);
   if (!botAuth.ok) {
     return botAuth.response;
   }

--- a/packages/relayer/app/api/v1/funds/[fundId]/intents/[intentHash]/onchain-executed/route.ts
+++ b/packages/relayer/app/api/v1/funds/[fundId]/intents/[intentHash]/onchain-executed/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireBotAuth } from "@/lib/bot-auth";
+import { requireBotAuthAsync } from "@/lib/bot-auth";
 import { requireFundBotRole } from "@/lib/fund-bot-authz";
 import { markExecutionJobExecutedByIntent } from "@/lib/supabase";
 
@@ -16,7 +16,7 @@ export async function POST(
   context: { params: Promise<{ fundId: string; intentHash: string }> }
 ) {
   const { fundId, intentHash } = await context.params;
-  const botAuth = requireBotAuth(request, ["intents.propose"]);
+  const botAuth = await requireBotAuthAsync(request, ["intents.propose"]);
   if (!botAuth.ok) {
     return botAuth.response;
   }

--- a/packages/relayer/app/api/v1/funds/[fundId]/intents/[intentHash]/onchain-failed/route.ts
+++ b/packages/relayer/app/api/v1/funds/[fundId]/intents/[intentHash]/onchain-failed/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireBotAuth } from "@/lib/bot-auth";
+import { requireBotAuthAsync } from "@/lib/bot-auth";
 import { requireFundBotRole } from "@/lib/fund-bot-authz";
 import { markExecutionJobRetryableByIntent } from "@/lib/supabase";
 
@@ -17,7 +17,7 @@ export async function POST(
   context: { params: Promise<{ fundId: string; intentHash: string }> }
 ) {
   const { fundId, intentHash } = await context.params;
-  const botAuth = requireBotAuth(request, ["intents.propose"]);
+  const botAuth = await requireBotAuthAsync(request, ["intents.propose"]);
   if (!botAuth.ok) {
     return botAuth.response;
   }

--- a/packages/relayer/app/api/v1/funds/[fundId]/intents/attestations/batch/route.ts
+++ b/packages/relayer/app/api/v1/funds/[fundId]/intents/attestations/batch/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireBotAuth } from "@/lib/bot-auth";
+import { requireBotAuthAsync } from "@/lib/bot-auth";
 import { isSameAddress, requireFundBotRole } from "@/lib/fund-bot-authz";
 import { ingestIntentAttestation } from "@/lib/aggregator";
 
@@ -9,7 +9,7 @@ export async function POST(
 ) {
   const { fundId } = await context.params;
 
-  const botAuth = requireBotAuth(request, ["intents.attest"]);
+  const botAuth = await requireBotAuthAsync(request, ["intents.attest"]);
   if (!botAuth.ok) {
     return botAuth.response;
   }

--- a/packages/relayer/app/api/v1/funds/[fundId]/intents/propose/route.ts
+++ b/packages/relayer/app/api/v1/funds/[fundId]/intents/propose/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireBotAuth } from "@/lib/bot-auth";
+import { requireBotAuthAsync } from "@/lib/bot-auth";
 import { requireFundBotRole } from "@/lib/fund-bot-authz";
 import {
   buildIntentAllowlistHashFromRoute,
@@ -25,7 +25,7 @@ export async function POST(
   context: { params: Promise<{ fundId: string }> }
 ) {
   const { fundId } = await context.params;
-  const botAuth = requireBotAuth(request, ["intents.propose"]);
+  const botAuth = await requireBotAuthAsync(request, ["intents.propose"]);
   if (!botAuth.ok) {
     return botAuth.response;
   }

--- a/packages/relayer/app/api/v1/funds/[fundId]/intents/ready-execution/route.ts
+++ b/packages/relayer/app/api/v1/funds/[fundId]/intents/ready-execution/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireBotAuth } from "@/lib/bot-auth";
+import { requireBotAuthAsync } from "@/lib/bot-auth";
 import { requireFundBotRole } from "@/lib/fund-bot-authz";
 import { listReadyExecutionPayloads } from "@/lib/supabase";
 
@@ -16,7 +16,7 @@ export async function GET(
   context: { params: Promise<{ fundId: string }> }
 ) {
   const { fundId } = await context.params;
-  const botAuth = requireBotAuth(request, ["intents.propose"]);
+  const botAuth = await requireBotAuthAsync(request, ["intents.propose"]);
   if (!botAuth.ok) {
     return botAuth.response;
   }

--- a/packages/relayer/lib/supabase.ts
+++ b/packages/relayer/lib/supabase.ts
@@ -477,6 +477,50 @@ export async function getFundBot(fundId: string, botId: string) {
     | null) ?? undefined;
 }
 
+export interface BotCredentialRow {
+  bot_id: string;
+  api_key: string;
+  scopes: string;
+  created_by: string;
+  created_at: number;
+  updated_at: number;
+}
+
+export async function upsertBotCredential(input: {
+  botId: string;
+  apiKey: string;
+  scopes: string;
+  createdBy: string;
+}) {
+  const db = supabase();
+  const now = nowMs();
+  const { error } = await db.from("bot_credentials").upsert(
+    {
+      bot_id: input.botId,
+      api_key: input.apiKey,
+      scopes: input.scopes,
+      created_by: input.createdBy,
+      created_at: now,
+      updated_at: now
+    },
+    {
+      onConflict: "bot_id"
+    }
+  );
+  throwIfError(error, null);
+}
+
+export async function getBotCredential(botId: string): Promise<BotCredentialRow | undefined> {
+  const db = supabase();
+  const { data, error } = await db
+    .from("bot_credentials")
+    .select("bot_id,api_key,scopes,created_by,created_at,updated_at")
+    .eq("bot_id", botId)
+    .maybeSingle();
+  throwIfError(error, null);
+  return (data as BotCredentialRow | null) ?? undefined;
+}
+
 export async function insertAttestation(input: {
   fundId: string;
   subjectType: SubjectType;

--- a/packages/relayer/next-env.d.ts
+++ b/packages/relayer/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/relayer/postman/README.md
+++ b/packages/relayer/postman/README.md
@@ -45,7 +45,8 @@ Required env in relayer `.env`:
 - `CLAIM_THRESHOLD_WEIGHT`
 - `INTENT_THRESHOLD_WEIGHT`
 - `VERIFIER_WEIGHT_SNAPSHOT`
-- `BOT_API_KEYS`, `BOT_SCOPES`
+- `SUPABASE_URL`, `SUPABASE_ANON_KEY`
+- `BOT_API_KEYS`, `BOT_SCOPES` (optional legacy fallback)
 
 ## 2) Import into Postman
 1. Import collection: `Claw-Relayer-v0.postman_collection.json`
@@ -75,7 +76,7 @@ And prints Postman environment values to copy:
 1. Sign in at `/login` and set `admin_auth_cookie` in Postman
 2. `POST /api/v1/funds` (admin creates fund metadata only)
    - includes `strategyBotId` + `strategyBotAddress` (single strategy bot for fund)
-3. `POST /api/v1/funds/bootstrap` (admin deploys onchain fund stack + persists deployment metadata)
+3. `POST /api/v1/funds/bootstrap` (admin deploys onchain fund stack + persists deployment metadata) (legacy)
 4. `POST /api/v1/funds/{fundId}/bots/register` (strategy bot registers participant bot)
 5. `GET /api/v1/funds/{fundId}/bots/register` (strategy bot verifies registry)
 6. `POST /api/v1/funds/{fundId}/claims` (participant submits canonical claim payload)
@@ -94,3 +95,8 @@ And prints Postman environment values to copy:
 - `POST /intents/propose` does not accept direct `allowlistHash`; relayer computes it from `executionRoute` only.
 - Collection now includes `funds/bootstrap`, `executions`, `cron/execute-intents`, and SSE endpoint (`events/intents`).
 - If you only want quick negative-path testing, use the `bad signature` requests in the collection.
+
+## Bot credentials note (recommended)
+- In production, prefer DB-backed bot credentials in Supabase `bot_credentials`.
+- Register the strategy bot credential during `POST /api/v1/funds/sync-by-strategy` by including `strategyBotApiKeySha256` (sha256 hex from bot-init).
+- Register participant bot credential during `POST /api/v1/funds/{fundId}/bots/register` by including `botApiKeySha256` (sha256 hex from that bot-init).

--- a/packages/relayer/scripts/e2e-db-auth.mjs
+++ b/packages/relayer/scripts/e2e-db-auth.mjs
@@ -1,0 +1,443 @@
+#!/usr/bin/env node
+/**
+ * End-to-end smoke to validate:
+ * - Supabase schema is applied (incl. bot_credentials)
+ * - DB-backed bot auth works (no BOT_API_KEYS/BOT_SCOPES needed)
+ * - Onchain fund deploy -> relayer sync-by-strategy bootstrap -> bot register -> claim -> aggregate -> intent -> attestation
+ *
+ * This is intentionally a smoke test: it does NOT execute trades onchain.
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+import {
+  createPublicClient,
+  createWalletClient,
+  decodeEventLog,
+  defineChain,
+  http,
+  parseAbi
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { intentAttestationTypedData } from "@claw/protocol-sdk";
+
+const FUND_FACTORY_ABI = parseAbi([
+  "function createFund((address fundOwner,address strategyAgent,address asset,string vaultName,string vaultSymbol,uint256 intentThresholdWeight,address nadfunLens,address[] initialVerifiers,uint256[] initialVerifierWeights,address[] initialAllowedTokens,address[] initialAllowedAdapters) cfg) returns (uint256 fundId, address intentBook, address core, address vault)",
+  "event FundDeployed(uint256 indexed fundId, address indexed fundOwner, address indexed strategyAgent, address intentBook, address core, address vault, address snapshotBook, address asset)"
+]);
+
+function env(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`missing required env: ${name}`);
+  return value;
+}
+
+function envOr(name, fallback) {
+  const value = process.env[name];
+  return value && value.length > 0 ? value : fallback;
+}
+
+function sha256Hex(value) {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function randomApiKey(label) {
+  return `${label}_${randomBytes(16).toString("hex")}`;
+}
+
+function parseAddress(name, value) {
+  if (!/^0x[a-fA-F0-9]{40}$/.test(value)) {
+    throw new Error(`${name} must be a valid 20-byte hex address`);
+  }
+  // viem simulateContract is strict about checksum for mixed-case strings.
+  // Normalize to lowercase to avoid checksum mismatch issues.
+  return value.toLowerCase();
+}
+
+function stringify(value) {
+  return JSON.stringify(
+    value,
+    (_, candidate) => (typeof candidate === "bigint" ? candidate.toString() : candidate),
+    2
+  );
+}
+
+function assertStatus(step, res, allowed) {
+  if (!allowed.includes(res.status)) {
+    throw new Error(`${step} failed: status=${res.status}`);
+  }
+}
+
+async function fetchJson(step, baseUrl, path, { method, headers, body }) {
+  const url = new URL(path, baseUrl).toString();
+  const response = await fetch(url, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body)
+  });
+  const text = await response.text();
+  let parsed;
+  try {
+    parsed = text ? JSON.parse(text) : null;
+  } catch {
+    parsed = text;
+  }
+  return { response, body: parsed, url };
+}
+
+function extractFundDeployedEvent(logs) {
+  for (const log of logs) {
+    try {
+      const decoded = decodeEventLog({
+        abi: FUND_FACTORY_ABI,
+        data: log.data,
+        topics: log.topics,
+        strict: false
+      });
+      if (decoded.eventName !== "FundDeployed") continue;
+      const args = decoded.args;
+      if (!args) continue;
+      return {
+        fundId: args.fundId,
+        fundOwner: args.fundOwner,
+        strategyAgent: args.strategyAgent,
+        intentBook: args.intentBook,
+        core: args.core,
+        vault: args.vault,
+        snapshotBook: args.snapshotBook,
+        asset: args.asset
+      };
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+async function main() {
+  const baseUrl = envOr("BASE_URL", "http://localhost:3000");
+
+  const chainId = Number(env("CHAIN_ID"));
+  const rpcUrl = env("RPC_URL");
+  const factoryAddress = parseAddress("CLAW_FUND_FACTORY_ADDRESS", env("CLAW_FUND_FACTORY_ADDRESS"));
+
+  const signerKey = envOr("FACTORY_SIGNER_PRIVATE_KEY", env("RELAYER_SIGNER_PRIVATE_KEY"));
+  const strategyAccount = privateKeyToAccount(signerKey);
+  const strategyBotAddress = strategyAccount.address;
+
+  // Participant only signs; doesn't need funds.
+  const participantKey = envOr("PARTICIPANT_PRIVATE_KEY", `0x${randomBytes(32).toString("hex")}`);
+  const participantAccount = privateKeyToAccount(participantKey);
+
+  const strategyBotId = envOr("STRATEGY_BOT_ID", "bot-strategy-1");
+  const participantBotId = envOr("PARTICIPANT_BOT_ID", "bot-participant-1");
+
+  const strategyBotApiKey = envOr("STRATEGY_BOT_API_KEY", randomApiKey("strategy"));
+  const participantBotApiKey = envOr("PARTICIPANT_BOT_API_KEY", randomApiKey("participant"));
+  const strategyBotApiKeySha256 = sha256Hex(strategyBotApiKey);
+  const participantBotApiKeySha256 = sha256Hex(participantBotApiKey);
+
+  const fundId = envOr("FUND_ID", `fund-e2e-${Date.now()}`);
+  const fundName = envOr("FUND_NAME", "OpenFunderse E2E DB-Auth");
+
+  const asset = parseAddress("ASSET", env("ASSET"));
+  const nadfunLens = parseAddress("NADFUN_LENS", env("NADFUN_LENS"));
+  const adapterAddress = parseAddress("ADAPTER_ADDRESS", env("ADAPTER_ADDRESS"));
+
+  const chain = defineChain({
+    id: chainId,
+    name: `claw-${chainId}`,
+    nativeCurrency: { name: "MON", symbol: "MON", decimals: 18 },
+    rpcUrls: { default: { http: [rpcUrl] }, public: { http: [rpcUrl] } }
+  });
+  const publicClient = createPublicClient({ chain, transport: http(rpcUrl) });
+  const strategyWalletClient = createWalletClient({
+    account: strategyAccount,
+    chain,
+    transport: http(rpcUrl)
+  });
+  const participantWalletClient = createWalletClient({
+    account: participantAccount,
+    chain,
+    transport: http(rpcUrl)
+  });
+
+  // 1) Deploy onchain fund stack OR reuse an existing deploy tx hash.
+  // Monad RPCs can be strict; if createFund simulation reverts, reuse an existing tx hash instead.
+  let txHash = envOr("DEPLOY_TX_HASH", "");
+  if (txHash) {
+    console.log("\n[e2e] using existing DEPLOY_TX_HASH (skipping onchain createFund)");
+  } else {
+    const deployConfig = {
+      fundOwner: strategyBotAddress,
+      strategyAgent: strategyBotAddress,
+      asset,
+      vaultName: envOr("VAULT_NAME", "OpenFunderse Vault Share"),
+      vaultSymbol: envOr("VAULT_SYMBOL", "OFVS"),
+      intentThresholdWeight: BigInt(envOr("INTENT_THRESHOLD_WEIGHT", "1")),
+      nadfunLens,
+      initialVerifiers: [participantAccount.address],
+      initialVerifierWeights: [1n],
+      initialAllowedTokens: [asset],
+      initialAllowedAdapters: [adapterAddress]
+    };
+
+    console.log("\n[e2e] onchain createFund deployConfig");
+    console.log(
+      stringify({
+        fundId,
+        fundName,
+        strategyBotId,
+        strategyBotAddress,
+        participantBotId,
+        participantAddress: participantAccount.address,
+        deployConfig
+      })
+    );
+
+    const simulation = await publicClient.simulateContract({
+      account: strategyAccount,
+      address: factoryAddress,
+      abi: FUND_FACTORY_ABI,
+      functionName: "createFund",
+      args: [deployConfig]
+    });
+    txHash = await strategyWalletClient.writeContract(simulation.request);
+    const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+    if (receipt.status !== "success") {
+      throw new Error(`createFund tx reverted: ${txHash}`);
+    }
+    const deployed = extractFundDeployedEvent(receipt.logs);
+    if (!deployed) {
+      throw new Error("FundDeployed event not found");
+    }
+    console.log("\n[e2e] onchain createFund receipt");
+    console.log(stringify({ txHash, blockNumber: receipt.blockNumber, deployed }));
+  }
+
+  // 2) Sync to relayer via signature bootstrap (no pre-existing bot credentials).
+  const expiresAt = Math.floor(Date.now() / 1000) + 600;
+  const nonce = `0x${randomBytes(16).toString("hex")}`;
+  const bootstrapMessage =
+    `OpenFunderse fund bootstrap\n` +
+    `fundId=${fundId}\n` +
+    `txHash=${txHash}\n` +
+    `strategyBotId=${strategyBotId}\n` +
+    `strategyBotAddress=${strategyBotAddress}\n` +
+    `strategyBotApiKeySha256=${strategyBotApiKeySha256}\n` +
+    `expiresAt=${expiresAt}\n` +
+    `nonce=${nonce}`;
+
+  const signature = await strategyWalletClient.signMessage({
+    account: strategyAccount,
+    message: bootstrapMessage
+  });
+
+  const sync = await fetchJson("sync-by-strategy", baseUrl, "/api/v1/funds/sync-by-strategy", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: {
+      fundId,
+      fundName,
+      strategyBotId,
+      strategyBotAddress,
+      txHash,
+      verifierThresholdWeight: "1",
+      intentThresholdWeight: "1",
+      strategyBotApiKeySha256: strategyBotApiKeySha256,
+      strategyBotScopes: "funds.bootstrap|bots.register|intents.propose",
+      auth: {
+        signature,
+        expiresAt,
+        nonce
+      }
+    }
+  });
+  assertStatus("sync-by-strategy", sync.response, [200]);
+  console.log("\n[e2e] relayer sync-by-strategy OK");
+  const onchainDeployment = sync.body?.onchainDeployment;
+  const intentBookAddress = onchainDeployment?.intentBookAddress;
+  const vaultAddress = onchainDeployment?.clawVaultAddress;
+  if (!intentBookAddress || !vaultAddress) {
+    throw new Error("sync-by-strategy response missing onchain deployment addresses");
+  }
+
+  // 3) Register participant bot (also persists participant credential to DB).
+  const strategyHeaders = {
+    "Content-Type": "application/json",
+    "x-bot-id": strategyBotId,
+    "x-bot-api-key": strategyBotApiKey
+  };
+
+  const register = await fetchJson("bots/register", baseUrl, `/api/v1/funds/${fundId}/bots/register`, {
+    method: "POST",
+    headers: strategyHeaders,
+    body: {
+      role: "participant",
+      botId: participantBotId,
+      botAddress: participantAccount.address,
+      botApiKeySha256: participantBotApiKeySha256,
+      botScopes: "claims.submit|intents.attest",
+      policyUri: "ipfs://participant-policy-e2e",
+      telegramHandle: "@participant_bot_e2e"
+    }
+  });
+  assertStatus("bots/register", register.response, [200]);
+
+  // 4) Submit allocation claim as participant using DB-backed auth.
+  const nowSec = BigInt(Math.floor(Date.now() / 1000));
+  const epochId = 1n;
+  const submitClaim = await fetchJson("claims", baseUrl, `/api/v1/funds/${fundId}/claims`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-bot-id": participantBotId,
+      "x-bot-api-key": participantBotApiKey
+    },
+    body: {
+      claim: {
+        claimVersion: "v1",
+        fundId,
+        epochId: epochId.toString(),
+        participant: participantAccount.address,
+        targetWeights: ["700000", "300000"],
+        horizonSec: "3600",
+        nonce: "1",
+        submittedAt: nowSec.toString()
+      }
+    }
+  });
+  assertStatus("claims", submitClaim.response, [200]);
+  const claimHash = submitClaim.body?.claimHash;
+  if (!claimHash) throw new Error("claimHash missing from /claims response");
+
+  // 5) Aggregate epoch as strategy.
+  const aggregate = await fetchJson("epochs/aggregate", baseUrl, `/api/v1/funds/${fundId}/epochs/${epochId.toString()}/aggregate`, {
+    method: "POST",
+    headers: strategyHeaders,
+    body: {}
+  });
+  assertStatus("epochs/aggregate", aggregate.response, [200]);
+
+  const latest = await fetchJson("epochs/latest", baseUrl, `/api/v1/funds/${fundId}/epochs/latest`, {
+    method: "GET",
+    headers: {}
+  });
+  assertStatus("epochs/latest", latest.response, [200]);
+  const snapshotHash = latest.body?.epochState?.epochStateHash ?? latest.body?.epochStateHash ?? latest.body?.epoch_state_hash;
+  if (!snapshotHash) throw new Error("snapshotHash missing from /epochs/latest response");
+
+  // 6) Propose intent bound to snapshotHash.
+  const vault = vaultAddress;
+  const tokenIn = asset;
+  const tokenOut = "0x00000000000000000000000000000000000000e2";
+  const minAmountOut = 1n;
+  const amountIn = 1n;
+  const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600);
+  const intent = {
+    intentVersion: "v1",
+    vault,
+    action: "SELL",
+    tokenIn,
+    tokenOut,
+    amountIn: amountIn.toString(),
+    minAmountOut: minAmountOut.toString(),
+    deadline: deadline.toString(),
+    maxSlippageBps: "300",
+    snapshotHash: snapshotHash,
+    reason: "e2e smoke"
+  };
+
+  const executionRoute = {
+    tokenIn,
+    tokenOut,
+    quoteAmountOut: "1",
+    minAmountOut: minAmountOut.toString(),
+    adapter: adapterAddress,
+    adapterData: "0x00"
+  };
+
+  const propose = await fetchJson("intents/propose", baseUrl, `/api/v1/funds/${fundId}/intents/propose`, {
+    method: "POST",
+    headers: strategyHeaders,
+    body: {
+      intent,
+      executionRoute,
+      maxNotional: amountIn.toString()
+    }
+  });
+  assertStatus("intents/propose", propose.response, [200]);
+  const intentHash = propose.body?.intentHash;
+  if (!intentHash) throw new Error("intentHash missing from /intents/propose response");
+
+  // 7) Attest intent (EIP-712) as participant.
+  const typed = intentAttestationTypedData({
+    chainId: BigInt(chainId),
+    intentBook: intentBookAddress,
+    intentHash,
+    verifier: participantAccount.address,
+    expiresAt: nowSec + 3600n,
+    nonce: 1n
+  });
+
+  const attestationSig = await participantWalletClient.signTypedData({
+    account: participantAccount,
+    domain: typed.domain,
+    types: typed.types,
+    primaryType: typed.primaryType,
+    message: typed.message
+  });
+
+  const attest = await fetchJson("intents/attestations/batch", baseUrl, `/api/v1/funds/${fundId}/intents/attestations/batch`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-bot-id": participantBotId,
+      "x-bot-api-key": participantBotApiKey
+    },
+    body: {
+      attestations: [
+        {
+          intentHash,
+          verifier: participantAccount.address,
+          expiresAt: (nowSec + 3600n).toString(),
+          nonce: "1",
+          signature: attestationSig
+        }
+      ]
+    }
+  });
+  assertStatus("intents/attestations/batch", attest.response, [200, 207]);
+
+  // 8) Fetch onchain bundle (strategy).
+  const bundle = await fetchJson("onchain-bundle", baseUrl, `/api/v1/funds/${fundId}/intents/${intentHash}/onchain-bundle`, {
+    method: "GET",
+    headers: {
+      "x-bot-id": strategyBotId,
+      "x-bot-api-key": strategyBotApiKey
+    }
+  });
+  assertStatus("onchain-bundle", bundle.response, [200]);
+
+  console.log("\n[e2e] SUCCESS");
+  console.log(
+    stringify({
+      baseUrl,
+      fundId,
+      txHash,
+      strategyBotId,
+      strategyBotAddress,
+      participantBotId,
+      participantAddress: participantAccount.address,
+      intentHash,
+      snapshotHash,
+      onchain: onchainDeployment,
+      note: "DB-backed bot auth validated via sync-by-strategy + bots/register; no BOT_API_KEYS required."
+    })
+  );
+}
+
+main().catch((error) => {
+  console.error("\n[e2e] FAILED");
+  console.error(error?.stack ?? String(error));
+  process.exit(1);
+});

--- a/packages/relayer/supabase/schema.sql
+++ b/packages/relayer/supabase/schema.sql
@@ -35,6 +35,18 @@ create table if not exists fund_bots (
   unique (fund_id, bot_id)
 );
 
+-- Bot credentials (API keys + scopes).
+-- Keys are stored as either plaintext (legacy) or "sha256:<64-hex>".
+create table if not exists bot_credentials (
+  id bigserial primary key,
+  bot_id text not null unique,
+  api_key text not null,
+  scopes text not null default '',
+  created_by text not null,
+  created_at bigint not null,
+  updated_at bigint not null
+);
+
 create table if not exists fund_deployments (
   id bigserial primary key,
   fund_id text not null unique,

--- a/treat-model-report.md
+++ b/treat-model-report.md
@@ -29,7 +29,7 @@
 ### E2. Strategy Bot (펀드 전략 주체)
 - 핵심 목적: participant 관리, intent 제안, 온체인 ACK.
 - 핵심 함수/엔드포인트:
-  - `requireBotAuth(..., ["intents.propose"|"bots.register"|"funds.bootstrap"])` (`/Users/wiimdy/agent/packages/relayer/lib/bot-auth.ts:53`)
+  - `requireBotAuthAsync(..., ["intents.propose"|"bots.register"|"funds.bootstrap"])` (`/Users/ham-yunsig/Documents/github/claw-validation-market/packages/relayer/lib/bot-auth.ts`)
   - `requireFundBotRole(..., allowedRoles:["strategy"])` (`/Users/wiimdy/agent/packages/relayer/lib/fund-bot-authz.ts:37`)
   - `POST /intents/propose` (`/Users/wiimdy/agent/packages/relayer/app/api/v1/funds/[fundId]/intents/propose/route.ts:23`)
   - `GET /intents/{intentHash}/onchain-bundle` (`/Users/wiimdy/agent/packages/relayer/app/api/v1/funds/[fundId]/intents/[intentHash]/onchain-bundle/route.ts:6`)
@@ -54,12 +54,13 @@
 
 ### E4. Relayer Auth/AuthZ 레이어
 - 핵심 함수:
-  - `requireBotAuth()` (`/Users/wiimdy/agent/packages/relayer/lib/bot-auth.ts:53`)
+  - `requireBotAuthAsync()` (`/Users/ham-yunsig/Documents/github/claw-validation-market/packages/relayer/lib/bot-auth.ts`)
   - `requireFundBotRole()` / `isSameAddress()` (`/Users/wiimdy/agent/packages/relayer/lib/fund-bot-authz.ts:37`)
   - `requireAdminSession()` (`/Users/wiimdy/agent/packages/relayer/lib/authz.ts:27`)
 - 상호작용:
   - 모든 쓰기 API의 첫 경계.
-  - `BOT_API_KEYS` + `BOT_SCOPES` + 펀드 멤버십 role 체크가 결합되어야 통과.
+  - (권장) Supabase `bot_credentials`에 등록된 key/scopes + 펀드 멤버십 role 체크가 결합되어야 통과.
+  - (레거시 fallback) `BOT_API_KEYS` + `BOT_SCOPES` env로도 통과 가능.
 
 ### E5. Aggregator / 상태전이 엔진
 - 핵심 함수:


### PR DESCRIPTION
## TL;DR
릴레이어 봇 인증을 Vercel 배포 `.env` 고정(`BOT_API_KEYS`/`BOT_SCOPES`)에서 Supabase DB(`bot_credentials`) 기반으로 전환했습니다.
- 펀드 등록(sync) 시 strategy 봇 키 등록
- participant 봇 등록 시 participant 키 등록
- 이후부터는 relayer 재배포 없이 봇 온보딩/키 회전 가능

## 배경 / 문제
- 기존: Vercel env에 `BOT_API_KEYS`/`BOT_SCOPES`를 박아야만 write API 호출 가능 → 봇 추가/교체/회전이 곧 relayer 재배포.
- 목표: fund/bot 등록 플로우 안에서 credential까지 등록되도록 하여 운영 friction 제거.

## 주요 변경
### 1) DB 스키마
- `packages/relayer/supabase/schema.sql`
  - `bot_credentials(bot_id unique, api_key, scopes, ...)` 추가
  - `api_key`는 plaintext(레거시) 또는 `sha256:<64hex>` 저장

### 2) Relayer Auth
- `packages/relayer/lib/bot-auth.ts`
  - `requireBotAuthAsync()` 도입: DB 조회 우선 → env fallback
  - 기존 `requireBotAuth()`는 await 누락을 잡기 위해 에러로 변경

### 3) Fund bootstrap (sync-by-strategy)
- `packages/relayer/app/api/v1/funds/sync-by-strategy/route.ts`
  - body에 `strategyBotApiKeySha256`를 받아 strategy credential을 DB에 upsert
  - 최초 등록을 위해 signature-based bootstrap(전략 주소 서명) 지원
  - `strategyBotScopes`(옵션) 저장 지원

### 4) Bot registration
- `packages/relayer/app/api/v1/funds/[fundId]/bots/register/route.ts`
  - `botApiKeySha256`/`botApiKey`/`botScopes`(옵션) 받으면 participant credential DB upsert

### 5) Agents / Installer / Skills / Docs 정리
- `packages/agents/src/lib/relayer-client.ts`
  - `sync-by-strategy` 호출 시 `BOT_API_KEY`로부터 `strategyBotApiKeySha256` 자동 포함
- `packages/openfunderse/bin/openfunderse.mjs`
  - bot-init 출력에서 더 이상 "BOT_API_KEYS 엔트리"를 유도하지 않고, sha256 등록 흐름 안내
- `packages/openfunderse/packs/*/SKILL.md`, `docs/*`
  - DB-backed credential 등록 흐름을 문서/스킬에 반영

## 테스트
- Supabase publishable key로 테이블 접근 가능 여부 확인(테이블 존재/권한 OK)
- 로컬 relayer + DB-auth용 e2e 스모크 스크립트 추가
  - `packages/relayer/scripts/e2e-db-auth.mjs`
  - 참고: 현재 Monad RPC/contract `createFund`가 reverts 나는 케이스가 있어, `DEPLOY_TX_HASH`로 기존 배포 tx를 재사용할 수 있게 우회 옵션 제공

## 운영 적용 체크리스트
1. Supabase SQL Editor에 `packages/relayer/supabase/schema.sql` 적용
2. Relayer 배포 env에 아래 설정
   - `SUPABASE_URL`, `SUPABASE_ANON_KEY` (필수)
   - `BOT_API_KEYS`/`BOT_SCOPES`는 레거시 fallback(선택)
3. Strategy 봇: `POST /api/v1/funds/sync-by-strategy` 실행 (최초는 signature bootstrap 가능)
4. Strategy 봇: `POST /api/v1/funds/{fundId}/bots/register`로 participant 봇 등록(+ `botApiKeySha256` 함께 등록 권장)

## TODO (후속)
- Postman collection JSON(`packages/relayer/postman/Claw-Relayer-v0.postman_collection.json`)에
  - `strategyBotApiKeySha256` / `botApiKeySha256` 예시 반영
- `createFund` revert 원인 파악(현재는 `DEPLOY_TX_HASH`로 우회 가능)
