### PR TITLE
feat(relayer): add claim/stake validation and harden aggregate pipeline

### DIFF
--- a/packages/relayer/app/api/v1/funds/[fundId]/bots/register/route.ts
+++ b/packages/relayer/app/api/v1/funds/[fundId]/bots/register/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireBotAuth } from "@/lib/bot-auth";
-import { getFund, listFundBots, upsertFundBot } from "@/lib/supabase";
+import { getFund, listFundBots, upsertFundBot, upsertStakeWeight } from "@/lib/supabase";
 
 const ALLOWED_ROLES = new Set(["participant"]);
 
@@ -77,6 +77,14 @@ export async function POST(
     telegramHandle: body.telegramHandle ? String(body.telegramHandle) : null,
     registeredBy: botAuth.botId
   });
+
+  if (role === "participant" && botAddress) {
+    await upsertStakeWeight({
+      fundId,
+      participant: botAddress,
+      weight: BigInt(1)
+    });
+  }
 
   return NextResponse.json(
     {

--- a/packages/relayer/app/api/v1/funds/[fundId]/claims/route.ts
+++ b/packages/relayer/app/api/v1/funds/[fundId]/claims/route.ts
@@ -11,6 +11,7 @@ import {
   insertAllocationClaim,
   listAllocationClaimsByFund
 } from "@/lib/supabase";
+import { parseFundAllowlistTokens, validateClaimDimensions } from "@/lib/claim-validation";
 
 export async function POST(
   request: Request,
@@ -94,6 +95,22 @@ export async function POST(
         receivedParticipant: claim.participant
       },
       { status: 403 }
+    );
+  }
+
+  const dimCheck = validateClaimDimensions({
+    targetWeightsLength: claim.targetWeights.length,
+    fundAllowlistTokens: parseFundAllowlistTokens(fund!)
+  });
+  if (!dimCheck.ok) {
+    return NextResponse.json(
+      {
+        error: "BAD_REQUEST",
+        message: dimCheck.message,
+        code: dimCheck.code,
+        ...dimCheck.detail
+      },
+      { status: 400 }
     );
   }
 

--- a/packages/relayer/app/api/v1/funds/[fundId]/stake-weights/route.ts
+++ b/packages/relayer/app/api/v1/funds/[fundId]/stake-weights/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import { requireBotAuth } from "@/lib/bot-auth";
+import { requireFundBotRole } from "@/lib/fund-bot-authz";
+import { getFundBot, upsertStakeWeight } from "@/lib/supabase";
+import { validateStakeWeightInput } from "@/lib/stake-validation";
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ fundId: string }> }
+) {
+  const { fundId } = await context.params;
+
+  const botAuth = await requireBotAuth(request, ["bots.register"]);
+  if (!botAuth.ok) return botAuth.response;
+
+  const membership = await requireFundBotRole({
+    fundId,
+    botId: botAuth.botId,
+    allowedRoles: ["strategy"]
+  });
+  if (!membership.ok) return membership.response;
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json(
+      { error: "BAD_REQUEST", message: "invalid json body" },
+      { status: 400 }
+    );
+  }
+
+  const validation = validateStakeWeightInput({
+    participant: String(body.participant ?? ""),
+    weight: String(body.weight ?? "")
+  });
+  if (!validation.ok) {
+    return NextResponse.json(
+      { error: "BAD_REQUEST", message: validation.message },
+      { status: 400 }
+    );
+  }
+
+  const participantBotId = String(body.participantBotId ?? "").trim();
+  if (!participantBotId) {
+    return NextResponse.json(
+      { error: "BAD_REQUEST", message: "participantBotId is required" },
+      { status: 400 }
+    );
+  }
+
+  const targetBot = await getFundBot(fundId, participantBotId);
+  if (
+    !targetBot ||
+    targetBot.status.toUpperCase() !== "ACTIVE" ||
+    targetBot.role !== "participant"
+  ) {
+    return NextResponse.json(
+      {
+        error: "NOT_FOUND",
+        message: "participant bot not found or not active in this fund"
+      },
+      { status: 404 }
+    );
+  }
+
+  await upsertStakeWeight({
+    fundId,
+    participant: validation.participant,
+    weight: validation.weight
+  });
+
+  return NextResponse.json(
+    {
+      status: "OK",
+      endpoint: "POST /api/v1/funds/{fundId}/stake-weights",
+      fundId,
+      participantBotId,
+      participant: validation.participant,
+      weight: validation.weight.toString()
+    },
+    { status: 200 }
+  );
+}

--- a/packages/relayer/app/api/v1/funds/sync-by-strategy/route.ts
+++ b/packages/relayer/app/api/v1/funds/sync-by-strategy/route.ts
@@ -169,6 +169,7 @@ export async function POST(request: Request) {
   let bootstrapAuth: { signature: string; nonce: string; expiresAt: string } | null;
   let verifierThresholdWeight: bigint;
   let intentThresholdWeight: bigint;
+  let allowlistTokens: string[] | undefined;
   try {
     fundId = asString(body.fundId);
     fundName = asString(body.fundName);
@@ -193,6 +194,12 @@ export async function POST(request: Request) {
     if (!strategyBotId) {
       throw new Error("strategyBotId is required");
     }
+
+    allowlistTokens = Array.isArray(body.allowlistTokens)
+      ? (body.allowlistTokens as unknown[])
+          .map((t) => String(t).trim())
+          .filter((t) => /^0x[a-fA-F0-9]{40}$/.test(t))
+      : undefined;
 
     verifierThresholdWeight =
       parseOptionalBigIntField(body.verifierThresholdWeight, "verifierThresholdWeight") ??
@@ -396,6 +403,7 @@ export async function POST(request: Request) {
     intentThresholdWeight,
     strategyPolicyUri: body.strategyPolicyUri ? String(body.strategyPolicyUri) : null,
     telegramRoomId: body.telegramRoomId ? String(body.telegramRoomId) : null,
+    allowlistTokens,
     createdBy: botAuth.ok ? botAuth.botId : strategyBotId
   });
 
@@ -420,7 +428,8 @@ export async function POST(request: Request) {
         strategyBotId,
         strategyBotAddress,
         verifierThresholdWeight: verifierThresholdWeight.toString(),
-        intentThresholdWeight: intentThresholdWeight.toString()
+        intentThresholdWeight: intentThresholdWeight.toString(),
+        allowlistTokens: allowlistTokens ?? []
       },
       onchainDeployment: {
         chainId: chainConfig.chainId.toString(),

--- a/packages/relayer/lib/aggregate-logic.ts
+++ b/packages/relayer/lib/aggregate-logic.ts
@@ -1,0 +1,101 @@
+export interface ClaimEntry {
+  participant: string;
+  weights: bigint[];
+  claimHash: string;
+}
+
+export interface AggregateFilterInput {
+  claims: ClaimEntry[];
+  registeredParticipants: Set<string>;
+  stakeMap: Map<string, bigint>;
+  expectedDimensions: number | null;
+}
+
+export interface FilteredClaim extends ClaimEntry {
+  stake: bigint;
+}
+
+export interface AggregateFilterOutput {
+  included: FilteredClaim[];
+  skipped: {
+    unregistered: string[];
+    noStake: string[];
+    dimensionMismatch: string[];
+  };
+}
+
+export function filterAndWeighClaims(
+  input: AggregateFilterInput
+): AggregateFilterOutput {
+  const { claims, registeredParticipants, stakeMap, expectedDimensions } = input;
+  const included: FilteredClaim[] = [];
+  const skipped = {
+    unregistered: [] as string[],
+    noStake: [] as string[],
+    dimensionMismatch: [] as string[]
+  };
+
+  let resolvedDim = expectedDimensions;
+
+  for (const claim of claims) {
+    const key = claim.participant.toLowerCase();
+
+    if (!registeredParticipants.has(key)) {
+      skipped.unregistered.push(key);
+      continue;
+    }
+
+    const stake = stakeMap.get(key) ?? BigInt(0);
+    if (stake <= BigInt(0)) {
+      skipped.noStake.push(key);
+      continue;
+    }
+
+    if (resolvedDim === null) {
+      resolvedDim = claim.weights.length;
+    }
+    if (claim.weights.length !== resolvedDim) {
+      skipped.dimensionMismatch.push(key);
+      continue;
+    }
+
+    included.push({ ...claim, stake });
+  }
+
+  return { included, skipped };
+}
+
+export function computeStakeWeightedAggregate(
+  participants: Array<{ weights: bigint[]; stake: bigint }>,
+  dimensions: number
+): bigint[] {
+  if (participants.length === 0) {
+    throw new Error("cannot compute aggregate with zero participants");
+  }
+
+  let totalStake = BigInt(0);
+  for (const p of participants) {
+    totalStake += p.stake;
+  }
+  if (totalStake <= BigInt(0)) {
+    throw new Error("total stake must be positive");
+  }
+
+  const aggregate = Array.from({ length: dimensions }, () => BigInt(0));
+  for (const p of participants) {
+    for (let i = 0; i < dimensions; i++) {
+      aggregate[i] += p.weights[i] * p.stake;
+    }
+  }
+
+  const result = aggregate.map((n) => n / totalStake);
+
+  const claimScale = participants[0].weights.reduce((a, b) => a + b, BigInt(0));
+  const resultSum = result.reduce((a, b) => a + b, BigInt(0));
+  const remainder = claimScale - resultSum;
+  if (remainder !== BigInt(0) && result.length > 0) {
+    result[0] += remainder;
+  }
+
+  return result;
+}

--- a/packages/relayer/lib/claim-validation.ts
+++ b/packages/relayer/lib/claim-validation.ts
@@ -1,0 +1,61 @@
+export interface FundAllowlistSource {
+  allowlist_tokens_json?: string | null;
+}
+
+export function parseFundAllowlistTokens(
+  fund: Pick<FundAllowlistSource, "allowlist_tokens_json">
+): string[] | null {
+  const raw = fund.allowlist_tokens_json;
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    return parsed
+      .map((t: unknown) => String(t).trim().toLowerCase())
+      .filter((t) => /^0x[a-fA-F0-9]{40}$/.test(t));
+  } catch {
+    return null;
+  }
+}
+
+export interface ClaimDimensionInput {
+  targetWeightsLength: number;
+  fundAllowlistTokens: string[] | null;
+}
+
+export type ClaimValidationResult =
+  | { ok: true }
+  | { ok: false; code: string; message: string; detail: Record<string, unknown> };
+
+export function validateClaimDimensions(
+  input: ClaimDimensionInput
+): ClaimValidationResult {
+  const { targetWeightsLength, fundAllowlistTokens } = input;
+
+  if (!fundAllowlistTokens || fundAllowlistTokens.length === 0) {
+    return { ok: true };
+  }
+
+  if (targetWeightsLength === 0) {
+    return {
+      ok: false,
+      code: "EMPTY_TARGET_WEIGHTS",
+      message: "targetWeights must not be empty",
+      detail: { expectedLength: fundAllowlistTokens.length, receivedLength: 0 }
+    };
+  }
+
+  if (targetWeightsLength !== fundAllowlistTokens.length) {
+    return {
+      ok: false,
+      code: "DIMENSION_MISMATCH",
+      message: `targetWeights length (${targetWeightsLength}) must match fund allowlist token count (${fundAllowlistTokens.length})`,
+      detail: {
+        expectedLength: fundAllowlistTokens.length,
+        receivedLength: targetWeightsLength
+      }
+    };
+  }
+
+  return { ok: true };
+}

--- a/packages/relayer/lib/stake-validation.ts
+++ b/packages/relayer/lib/stake-validation.ts
@@ -1,0 +1,30 @@
+export interface StakeWeightInputRaw {
+  participant: string;
+  weight: string;
+}
+
+export type StakeValidationResult =
+  | { ok: true; participant: string; weight: bigint }
+  | { ok: false; message: string };
+
+export function validateStakeWeightInput(
+  input: StakeWeightInputRaw
+): StakeValidationResult {
+  const participant = input.participant.trim().toLowerCase();
+  if (!/^0x[a-fA-F0-9]{40}$/.test(participant)) {
+    return { ok: false, message: "participant must be a valid 20-byte hex address" };
+  }
+
+  let weight: bigint;
+  try {
+    weight = BigInt(input.weight);
+  } catch {
+    return { ok: false, message: "weight must be a valid integer" };
+  }
+
+  if (weight < BigInt(0)) {
+    return { ok: false, message: "weight must be non-negative" };
+  }
+
+  return { ok: true, participant, weight };
+}

--- a/packages/relayer/next-env.d.ts
+++ b/packages/relayer/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/relayer/package.json
+++ b/packages/relayer/package.json
@@ -12,7 +12,8 @@
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx",
     "factory:create-fund": "node scripts/factory-create-fund.mjs",
-    "smoke:all-apis": "node scripts/smoke-all-apis.mjs"
+    "smoke:all-apis": "node scripts/smoke-all-apis.mjs",
+    "test": "npx tsx --test test/**/*.test.ts"
   },
   "dependencies": {
     "@claw/protocol-sdk": "file:../sdk",

--- a/packages/relayer/supabase/schema.sql
+++ b/packages/relayer/supabase/schema.sql
@@ -19,6 +19,7 @@ create table if not exists funds (
 alter table if exists funds add column if not exists is_verified boolean not null default false;
 alter table if exists funds add column if not exists visibility text not null default 'HIDDEN';
 alter table if exists funds add column if not exists verification_note text;
+alter table if exists funds add column if not exists allowlist_tokens_json text;
 
 create table if not exists fund_bots (
   id bigserial primary key,

--- a/packages/relayer/test/aggregate-logic.test.ts
+++ b/packages/relayer/test/aggregate-logic.test.ts
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  filterAndWeighClaims,
+  computeStakeWeightedAggregate,
+  type ClaimEntry,
+} from "../lib/aggregate-logic.ts";
+
+const SCALE = 1_000_000_000_000_000_000n; // 1e18 — matches CLAIM_WEIGHT_SCALE
+
+const PARTICIPANT_A = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const PARTICIPANT_B = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const PARTICIPANT_C = "0xcccccccccccccccccccccccccccccccccccccccc";
+
+function makeWeights6(fractions: number[]): bigint[] {
+  assert.equal(fractions.length, 6, "must provide 6 fractions");
+  const raw = fractions.map((f) => BigInt(Math.floor(f * 1e18)));
+  const sum = raw.reduce((a, b) => a + b, 0n);
+  raw[0] += SCALE - sum;
+  return raw;
+}
+
+test("filterAndWeighClaims: unregistered participant excluded", () => {
+  const claims: ClaimEntry[] = [
+    { participant: PARTICIPANT_A, weights: makeWeights6([1, 0, 0, 0, 0, 0]), claimHash: "0xaaa" }
+  ];
+  const result = filterAndWeighClaims({
+    claims,
+    registeredParticipants: new Set<string>(),
+    stakeMap: new Map([[PARTICIPANT_A, 100n]]),
+    expectedDimensions: 6
+  });
+
+  assert.equal(result.included.length, 0);
+  assert.deepEqual(result.skipped.unregistered, [PARTICIPANT_A]);
+});
+
+test("filterAndWeighClaims: no stake → excluded (no BigInt(1) fallback)", () => {
+  const claims: ClaimEntry[] = [
+    { participant: PARTICIPANT_A, weights: makeWeights6([0.5, 0.1, 0.1, 0.1, 0.1, 0.1]), claimHash: "0xaaa" }
+  ];
+  const result = filterAndWeighClaims({
+    claims,
+    registeredParticipants: new Set([PARTICIPANT_A]),
+    stakeMap: new Map(),
+    expectedDimensions: 6
+  });
+
+  assert.equal(result.included.length, 0);
+  assert.deepEqual(result.skipped.noStake, [PARTICIPANT_A]);
+});
+
+test("filterAndWeighClaims: stake=0 → excluded", () => {
+  const claims: ClaimEntry[] = [
+    { participant: PARTICIPANT_A, weights: makeWeights6([1, 0, 0, 0, 0, 0]), claimHash: "0xaaa" }
+  ];
+  const result = filterAndWeighClaims({
+    claims,
+    registeredParticipants: new Set([PARTICIPANT_A]),
+    stakeMap: new Map([[PARTICIPANT_A, 0n]]),
+    expectedDimensions: 6
+  });
+
+  assert.equal(result.included.length, 0);
+  assert.deepEqual(result.skipped.noStake, [PARTICIPANT_A]);
+});
+
+test("filterAndWeighClaims: dimension mismatch excluded (3 weights vs expected 6)", () => {
+  const claims: ClaimEntry[] = [
+    { participant: PARTICIPANT_A, weights: [SCALE / 3n, SCALE / 3n, SCALE / 3n], claimHash: "0xaaa" }
+  ];
+  const result = filterAndWeighClaims({
+    claims,
+    registeredParticipants: new Set([PARTICIPANT_A]),
+    stakeMap: new Map([[PARTICIPANT_A, 10n]]),
+    expectedDimensions: 6
+  });
+
+  assert.equal(result.included.length, 0);
+  assert.deepEqual(result.skipped.dimensionMismatch, [PARTICIPANT_A]);
+});
+
+test("filterAndWeighClaims: expectedDimensions=null → first valid claim sets dimension", () => {
+  const w6 = makeWeights6([0.2, 0.2, 0.2, 0.2, 0.1, 0.1]);
+  const w3 = [SCALE / 3n, SCALE / 3n, SCALE / 3n];
+  const claims: ClaimEntry[] = [
+    { participant: PARTICIPANT_A, weights: w6, claimHash: "0xaaa" },
+    { participant: PARTICIPANT_B, weights: w3, claimHash: "0xbbb" }
+  ];
+  const result = filterAndWeighClaims({
+    claims,
+    registeredParticipants: new Set([PARTICIPANT_A, PARTICIPANT_B]),
+    stakeMap: new Map([
+      [PARTICIPANT_A, 5n],
+      [PARTICIPANT_B, 5n]
+    ]),
+    expectedDimensions: null
+  });
+
+  assert.equal(result.included.length, 1);
+  assert.equal(result.included[0].participant, PARTICIPANT_A);
+  assert.deepEqual(result.skipped.dimensionMismatch, [PARTICIPANT_B]);
+});
+
+test("filterAndWeighClaims: all valid → all included with correct stake", () => {
+  const wA = makeWeights6([0.5, 0.1, 0.1, 0.1, 0.1, 0.1]);
+  const wB = makeWeights6([0.1, 0.5, 0.1, 0.1, 0.1, 0.1]);
+  const claims: ClaimEntry[] = [
+    { participant: PARTICIPANT_A, weights: wA, claimHash: "0xaaa" },
+    { participant: PARTICIPANT_B, weights: wB, claimHash: "0xbbb" }
+  ];
+  const result = filterAndWeighClaims({
+    claims,
+    registeredParticipants: new Set([PARTICIPANT_A, PARTICIPANT_B]),
+    stakeMap: new Map([
+      [PARTICIPANT_A, 100n],
+      [PARTICIPANT_B, 200n]
+    ]),
+    expectedDimensions: 6
+  });
+
+  assert.equal(result.included.length, 2);
+  assert.equal(result.included[0].stake, 100n);
+  assert.equal(result.included[1].stake, 200n);
+  assert.equal(result.skipped.unregistered.length, 0);
+  assert.equal(result.skipped.noStake.length, 0);
+  assert.equal(result.skipped.dimensionMismatch.length, 0);
+});
+
+test("computeStakeWeightedAggregate: equal stake → simple average", () => {
+  // 100% ZEN vs 100% tFOMA, equal stake → expect ~50/50
+  const wA = makeWeights6([1, 0, 0, 0, 0, 0]);
+  const wB = makeWeights6([0, 1, 0, 0, 0, 0]);
+  const result = computeStakeWeightedAggregate(
+    [
+      { weights: wA, stake: 10n },
+      { weights: wB, stake: 10n }
+    ],
+    6
+  );
+
+  const sum = result.reduce((a, b) => a + b, 0n);
+  assert.equal(sum, SCALE, "aggregate must sum to SCALE");
+  assert.ok(result[0] >= SCALE / 2n - 1n && result[0] <= SCALE / 2n + 1n);
+  assert.ok(result[1] >= SCALE / 2n - 1n && result[1] <= SCALE / 2n + 1n);
+});
+
+test("computeStakeWeightedAggregate: unequal stake → weighted toward heavier", () => {
+  // stake 3:1 ratio → expect ~75/25 split
+  const wA = makeWeights6([1, 0, 0, 0, 0, 0]);
+  const wB = makeWeights6([0, 1, 0, 0, 0, 0]);
+  const result = computeStakeWeightedAggregate(
+    [
+      { weights: wA, stake: 3n },
+      { weights: wB, stake: 1n }
+    ],
+    6
+  );
+
+  const sum = result.reduce((a, b) => a + b, 0n);
+  assert.equal(sum, SCALE);
+  assert.ok(result[0] >= (SCALE * 3n) / 4n - 1n && result[0] <= (SCALE * 3n) / 4n + 1n);
+  assert.ok(result[1] >= SCALE / 4n - 1n && result[1] <= SCALE / 4n + 1n);
+});
+
+test("computeStakeWeightedAggregate: single participant → same weights", () => {
+  const w = makeWeights6([0.3, 0.2, 0.15, 0.15, 0.1, 0.1]);
+  const result = computeStakeWeightedAggregate([{ weights: w, stake: 42n }], 6);
+
+  const sum = result.reduce((a, b) => a + b, 0n);
+  assert.equal(sum, SCALE);
+  assert.deepEqual(result, w);
+});
+
+test("computeStakeWeightedAggregate: rounding remainder → sum equals SCALE", () => {
+  // 3 participants with prime-number stakes to force integer division rounding
+  const wA = makeWeights6([0.333, 0.333, 0.334, 0, 0, 0]);
+  const wB = makeWeights6([0, 0, 0, 0.333, 0.333, 0.334]);
+  const wC = makeWeights6([0.167, 0.167, 0.166, 0.167, 0.167, 0.166]);
+
+  const result = computeStakeWeightedAggregate(
+    [
+      { weights: wA, stake: 7n },
+      { weights: wB, stake: 11n },
+      { weights: wC, stake: 13n }
+    ],
+    6
+  );
+
+  const sum = result.reduce((a, b) => a + b, 0n);
+  assert.equal(sum, SCALE, "aggregate must always sum to SCALE after rounding correction");
+});
+
+test("computeStakeWeightedAggregate: empty participants → throws", () => {
+  assert.throws(
+    () => computeStakeWeightedAggregate([], 6),
+    { message: "cannot compute aggregate with zero participants" }
+  );
+});
+
+test("computeStakeWeightedAggregate: 6-token realistic scenario with 3 participants", () => {
+  // A(stake=5): 40%ZEN 20%tFOMA 10%×4 | B(stake=3): 50%MONAI 10%×5 | C(stake=2): ~16.67%×6
+  const wA = makeWeights6([0.40, 0.20, 0.10, 0.10, 0.10, 0.10]);
+  const wB = makeWeights6([0.10, 0.10, 0.50, 0.10, 0.10, 0.10]);
+  const wC = makeWeights6([1 / 6, 1 / 6, 1 / 6, 1 / 6, 1 / 6, 1 / 6]);
+
+  const result = computeStakeWeightedAggregate(
+    [
+      { weights: wA, stake: 5n },
+      { weights: wB, stake: 3n },
+      { weights: wC, stake: 2n }
+    ],
+    6
+  );
+
+  const sum = result.reduce((a, b) => a + b, 0n);
+  assert.equal(sum, SCALE, "aggregate must sum to SCALE");
+
+  for (let i = 0; i < 6; i++) {
+    assert.ok(result[i] > 0n, `result[${i}] should be positive`);
+  }
+
+  assert.ok(result[0] > result[3], "ZEN should be weighted higher than PFROG");
+  assert.ok(result[2] > result[3], "MONAI should be weighted higher than PFROG");
+});

--- a/packages/relayer/test/claim-validation.test.ts
+++ b/packages/relayer/test/claim-validation.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  parseFundAllowlistTokens,
+  validateClaimDimensions
+} from '../lib/claim-validation';
+
+const TOKEN_A = '0x1111111111111111111111111111111111111111';
+const TOKEN_B = '0x2222222222222222222222222222222222222222';
+
+test('parseFundAllowlistTokens parses valid allowlist json', () => {
+  const parsed = parseFundAllowlistTokens({
+    allowlist_tokens_json: JSON.stringify([TOKEN_A, TOKEN_B])
+  });
+  assert.deepEqual(parsed, [TOKEN_A, TOKEN_B]);
+});
+
+test('parseFundAllowlistTokens returns null for null input', () => {
+  const parsed = parseFundAllowlistTokens({ allowlist_tokens_json: null });
+  assert.equal(parsed, null);
+});
+
+test('parseFundAllowlistTokens returns null for undefined input', () => {
+  const parsed = parseFundAllowlistTokens({});
+  assert.equal(parsed, null);
+});
+
+test('parseFundAllowlistTokens returns null for malformed json', () => {
+  const parsed = parseFundAllowlistTokens({ allowlist_tokens_json: '{bad-json' });
+  assert.equal(parsed, null);
+});
+
+test('parseFundAllowlistTokens returns null for non-array json', () => {
+  const parsed = parseFundAllowlistTokens({
+    allowlist_tokens_json: JSON.stringify({ token: TOKEN_A })
+  });
+  assert.equal(parsed, null);
+});
+
+test('parseFundAllowlistTokens normalizes and filters invalid entries', () => {
+  const parsed = parseFundAllowlistTokens({
+    allowlist_tokens_json: JSON.stringify(['  0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA  ', '0x1234', 42])
+  });
+  assert.deepEqual(parsed, ['0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
+});
+
+test('validateClaimDimensions passes when fund allowlist is null', () => {
+  const result = validateClaimDimensions({ targetWeightsLength: 0, fundAllowlistTokens: null });
+  assert.deepEqual(result, { ok: true });
+});
+
+test('validateClaimDimensions passes when fund allowlist is empty', () => {
+  const result = validateClaimDimensions({ targetWeightsLength: 2, fundAllowlistTokens: [] });
+  assert.deepEqual(result, { ok: true });
+});
+
+test('validateClaimDimensions passes when lengths match', () => {
+  const result = validateClaimDimensions({
+    targetWeightsLength: 2,
+    fundAllowlistTokens: [TOKEN_A, TOKEN_B]
+  });
+  assert.deepEqual(result, { ok: true });
+});
+
+test('validateClaimDimensions rejects empty targetWeights for non-empty allowlist', () => {
+  const result = validateClaimDimensions({ targetWeightsLength: 0, fundAllowlistTokens: [TOKEN_A] });
+  assert.deepEqual(result, {
+    ok: false,
+    code: 'EMPTY_TARGET_WEIGHTS',
+    message: 'targetWeights must not be empty',
+    detail: { expectedLength: 1, receivedLength: 0 }
+  });
+});
+
+test('validateClaimDimensions rejects mismatched lengths', () => {
+  const result = validateClaimDimensions({
+    targetWeightsLength: 1,
+    fundAllowlistTokens: [TOKEN_A, TOKEN_B]
+  });
+  assert.deepEqual(result, {
+    ok: false,
+    code: 'DIMENSION_MISMATCH',
+    message: 'targetWeights length (1) must match fund allowlist token count (2)',
+    detail: { expectedLength: 2, receivedLength: 1 }
+  });
+});
+
+test('validateClaimDimensions passes for single-token allowlist with one target weight', () => {
+  const result = validateClaimDimensions({ targetWeightsLength: 1, fundAllowlistTokens: [TOKEN_A] });
+  assert.deepEqual(result, { ok: true });
+});

--- a/packages/relayer/test/stake-weight.test.ts
+++ b/packages/relayer/test/stake-weight.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { validateStakeWeightInput } from "../lib/stake-validation.ts";
+
+test("valid positive weight returns ok with normalized address", () => {
+  const result = validateStakeWeightInput({
+    participant: " 0xAbCdEf0000000000000000000000000000001234 ",
+    weight: "42"
+  });
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.participant, "0xabcdef0000000000000000000000000000001234");
+    assert.equal(result.weight, BigInt(42));
+  }
+});
+
+test("weight of zero is accepted", () => {
+  const result = validateStakeWeightInput({
+    participant: "0x1111111111111111111111111111111111111111",
+    weight: "0"
+  });
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.weight, BigInt(0));
+  }
+});
+
+test("negative weight is rejected", () => {
+  const result = validateStakeWeightInput({
+    participant: "0x2222222222222222222222222222222222222222",
+    weight: "-1"
+  });
+
+  assert.deepEqual(result, { ok: false, message: "weight must be non-negative" });
+});
+
+test("non-numeric weight is rejected", () => {
+  const result = validateStakeWeightInput({
+    participant: "0x3333333333333333333333333333333333333333",
+    weight: "abc"
+  });
+
+  assert.deepEqual(result, { ok: false, message: "weight must be a valid integer" });
+});
+
+test("invalid address is rejected", () => {
+  const result = validateStakeWeightInput({
+    participant: "0x123",
+    weight: "5"
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    message: "participant must be a valid 20-byte hex address"
+  });
+});
+
+test("empty participant is rejected", () => {
+  const result = validateStakeWeightInput({
+    participant: "   ",
+    weight: "5"
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    message: "participant must be a valid 20-byte hex address"
+  });
+});
+
+test("very large weight is accepted", () => {
+  const large = "340282366920938463463374607431768211455";
+  const result = validateStakeWeightInput({
+    participant: "0x9999999999999999999999999999999999999999",
+    weight: large
+  });
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.weight, BigInt(large));
+  }
+});


### PR DESCRIPTION
## Summary

Strengthen the relayer's offchain validation pipeline by adding asset whitelist enforcement, stake weight lifecycle management, and hardened epoch aggregation — closing the gap between onchain constraints (`ClawVault4626.isTokenAllowed`, `allowlistHash`) and offchain claim submission.

- Add **claim dimension validation** — reject claims where `targetWeights.length` doesn't match the fund's registered allowlist token count (6 tokens)
- Add **stake weight lifecycle** — seed initial weight on participant registration, expose strategy-only API for updates, eliminate the `BigInt(1)` fallback that let unregistered participants influence aggregation
- **Harden aggregate route** — extract filter/compute into pure testable functions, filter out unregistered participants and zero-stake entries, validate claim dimensions, return validation metadata in response
- Add **31 tests** (relayer previously had zero) covering all three validation modules

## Motivation

The contract layer (`ClawCore.executeIntent`) enforces `allowlistHash` verification at execution time, but the entire claim→aggregate→intent offchain pipeline had **no dimension or registration checks**. This meant:
1. Claims with wrong `targetWeights` length could be submitted and aggregated
2. Any address could influence aggregation without being registered (`BigInt(1)` fallback at `aggregate/route.ts:129`)
3. The `stake_weights` table existed but was a dead table — no insert/update path existed

## Changes

### New files (6)
| File | Purpose |
|------|---------|
| `lib/claim-validation.ts` | `parseFundAllowlistTokens`, `validateClaimDimensions` — pure, no Next.js imports |
| `lib/stake-validation.ts` | `validateStakeWeightInput` — address/weight parsing and validation |
| `lib/aggregate-logic.ts` | `filterAndWeighClaims`, `computeStakeWeightedAggregate` — pure functions |
| `stake-weights/route.ts` | `POST /api/v1/funds/{fundId}/stake-weights` — strategy-only stake update API |
| `test/claim-validation.test.ts` | 12 test cases |
| `test/stake-weight.test.ts` | 7 test cases |
| `test/aggregate-logic.test.ts` | 12 test cases |

### Modified files (8)
| File | Change |
|------|--------|
| `supabase/schema.sql` | `ALTER TABLE funds ADD COLUMN allowlist_tokens_json TEXT` |
| `lib/supabase.ts` | `FundRow` type update, `upsertStakeWeight`, `listActiveFundParticipants`, `listStakeWeightsByFund` |
| `claims/route.ts` | Wire `validateClaimDimensions` before `buildCanonicalAllocationClaimRecord` |
| `sync-by-strategy/route.ts` | Accept `allowlistTokens[]` in body, validate as addresses, store via `upsertFund` |
| `bots/register/route.ts` | Seed `stake_weight=1` on participant registration |
| `aggregate/route.ts` | Replace inline logic with `filterAndWeighClaims` + `computeStakeWeightedAggregate`, add validation metadata |
| `package.json` | Add `"test"` script |

## Test coverage

```
31 tests, 0 failures (node:test + node:assert/strict via tsx)

claim-validation:  12/12  (parse allowlist, dimension match/mismatch)
stake-weight:       7/7   (address validation, weight bounds)
aggregate-logic:   12/12  (filter exclusions, weighted aggregation, rounding, 6-token scenarios)
```

## Merge safety

- Base: `ace67b5` (current `main`)
- main divergence: 1 commit (`packages/agents/` only) — **0 conflicts**, no relayer file overlap
- Build: `npm run build -w @claw/relayer` passes