### PR TITLE
feat(openfunderse): support symlink install and .openclaw default

### DIFF
--- a/packages/openfunderse/README.md
+++ b/packages/openfunderse/README.md
@@ -1,6 +1,6 @@
 # openfunderse
 
-Install OpenFunderse skill packs into Codex.
+Install OpenFunderse skill packs into OpenClaw.
 
 ## Role
 - Monorepo distribution package for Codex skills/prompts/manifests.
@@ -12,7 +12,7 @@ Install OpenFunderse skill packs into Codex.
 # list bundled packs
 npx @wiimdy/openfunderse@latest list
 
-# install pack into ~/.codex/skills
+# install pack into ~/.openclaw/skills
 npx @wiimdy/openfunderse@latest install openfunderse
 
 # install pack as symlinks (good for local development / fast updates)
@@ -21,8 +21,8 @@ npx @wiimdy/openfunderse@latest install openfunderse --link
 # install pack + runtime package in one command (recommended)
 npx @wiimdy/openfunderse@latest install openfunderse --with-runtime
 
-# install into custom codex home
-npx @wiimdy/openfunderse@latest install openfunderse --codex-home /custom/.codex
+# install into custom OpenClaw home
+npx @wiimdy/openfunderse@latest install openfunderse --openclaw-home /custom/.openclaw
 
 # install runtime into a specific project directory
 npx @wiimdy/openfunderse@latest install openfunderse \
@@ -32,11 +32,12 @@ npx @wiimdy/openfunderse@latest install openfunderse \
 
 ## Notes
 
-- Skills are copied into `$CODEX_HOME/skills` (default `~/.codex/skills`).
-- `--link` installs skills as symlinks from `$CODEX_HOME/packs/<pack-name>/skills/*` into `$CODEX_HOME/skills/*`.
-- Pack metadata/prompts are copied into `$CODEX_HOME/packs/<pack-name>`.
+- Skills are copied into `$OPENCLAW_HOME/skills` (default `~/.openclaw/skills`).
+- `--link` installs skills as symlinks from `$OPENCLAW_HOME/packs/<pack-name>/skills/*` into `$OPENCLAW_HOME/skills/*`.
+- Pack metadata/prompts are copied into `$OPENCLAW_HOME/packs/<pack-name>`.
 - Use `--force` to overwrite existing installed skills.
 - `--with-runtime` installs `@wiimdy/openfunderse-agents` into the current project (`package.json` required).
 - Optional: `--runtime-package`, `--runtime-dir`, `--runtime-manager`.
+- Backward compatibility: `--codex-home` and `CODEX_HOME` are still accepted as aliases.
 - Default unified bundle is `clawbot-core` (strategy + participant role actions).
 - Installer prints each installed skill with its `SKILL.md` name/description so users can see what was added.

--- a/packages/openfunderse/README.md
+++ b/packages/openfunderse/README.md
@@ -15,6 +15,9 @@ npx @wiimdy/openfunderse@latest list
 # install pack into ~/.codex/skills
 npx @wiimdy/openfunderse@latest install openfunderse
 
+# install pack as symlinks (good for local development / fast updates)
+npx @wiimdy/openfunderse@latest install openfunderse --link
+
 # install pack + runtime package in one command (recommended)
 npx @wiimdy/openfunderse@latest install openfunderse --with-runtime
 
@@ -30,8 +33,10 @@ npx @wiimdy/openfunderse@latest install openfunderse \
 ## Notes
 
 - Skills are copied into `$CODEX_HOME/skills` (default `~/.codex/skills`).
+- `--link` installs skills as symlinks from `$CODEX_HOME/packs/<pack-name>/skills/*` into `$CODEX_HOME/skills/*`.
 - Pack metadata/prompts are copied into `$CODEX_HOME/packs/<pack-name>`.
 - Use `--force` to overwrite existing installed skills.
 - `--with-runtime` installs `@wiimdy/openfunderse-agents` into the current project (`package.json` required).
 - Optional: `--runtime-package`, `--runtime-dir`, `--runtime-manager`.
 - Default unified bundle is `clawbot-core` (strategy + participant role actions).
+- Installer prints each installed skill with its `SKILL.md` name/description so users can see what was added.

--- a/packages/openfunderse/bin/openfunderse.mjs
+++ b/packages/openfunderse/bin/openfunderse.mjs
@@ -17,7 +17,7 @@ function printUsage() {
 
 Usage:
   openfunderse list
-  openfunderse install <pack-name> [--dest <skills-dir>] [--codex-home <dir>] [--force] [--link] [--with-runtime]
+  openfunderse install <pack-name> [--dest <skills-dir>] [--openclaw-home <dir>] [--force] [--link] [--with-runtime]
                      [--runtime-package <name>] [--runtime-dir <dir>] [--runtime-manager <npm|pnpm|yarn|bun>]
 
 Examples:
@@ -25,7 +25,7 @@ Examples:
   openfunderse install openfunderse
   openfunderse install openfunderse --link
   openfunderse install openfunderse --with-runtime
-  openfunderse install openfunderse --codex-home /tmp/codex-home
+  openfunderse install openfunderse --openclaw-home /tmp/.openclaw
 `);
 }
 
@@ -36,7 +36,7 @@ function parseArgs(argv) {
     force: false,
     link: false,
     dest: "",
-    codexHome: "",
+    openclawHome: "",
     withRuntime: false,
     runtimePackage: "",
     runtimeDir: "",
@@ -63,8 +63,8 @@ function parseArgs(argv) {
       i += 1;
       continue;
     }
-    if (token === "--codex-home") {
-      options.codexHome = args[i + 1] ?? "";
+    if (token === "--openclaw-home" || token === "--codex-home") {
+      options.openclawHome = args[i + 1] ?? "";
       i += 1;
       continue;
     }
@@ -96,8 +96,8 @@ function parseArgs(argv) {
   return { command, options, positionals };
 }
 
-function defaultCodexHome() {
-  return process.env.CODEX_HOME || path.join(os.homedir(), ".codex");
+function defaultOpenClawHome() {
+  return process.env.OPENCLAW_HOME || process.env.CODEX_HOME || path.join(os.homedir(), ".openclaw");
 }
 
 function ensureUnderRoot(root, target) {
@@ -275,11 +275,13 @@ async function installPack(packName, options) {
     throw new Error("manifest has no bundles");
   }
 
-  const codexHome = options.codexHome ? path.resolve(options.codexHome) : defaultCodexHome();
+  const openclawHome = options.openclawHome
+    ? path.resolve(options.openclawHome)
+    : defaultOpenClawHome();
   const skillsRoot = options.dest
     ? path.resolve(options.dest)
-    : path.join(codexHome, "skills");
-  const packMetaRoot = path.join(codexHome, "packs", packName);
+    : path.join(openclawHome, "skills");
+  const packMetaRoot = path.join(openclawHome, "packs", packName);
 
   await mkdir(path.dirname(path.join(packMetaRoot, "_")), { recursive: true });
   await cp(packDir, packMetaRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Default install home to `.openclaw`.
- Add symlink install mode and improve installed skill visibility.

## Test plan
- [ ] Install pack with symlink mode
- [ ] Validate skills are discoverable by OpenClaw
